### PR TITLE
oteldemo: Service Detail metric cards + batched fetch

### DIFF
--- a/oteldemo/src/api/queries.ts
+++ b/oteldemo/src/api/queries.ts
@@ -642,3 +642,344 @@ export function metricSampleRow(metricName: string): string {
     | where _metric == "${m}"
     | limit 1`;
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Spanmetrics-backed RED queries
+//
+// The OTel Collector's spanmetrics connector synthesizes two metrics
+// from every span it processes:
+//   - traces.span.metrics.calls    — monotonic counter
+//   - traces.span.metrics.duration — histogram, bucket bounds in ms
+// Both are tagged with at least (service.name, span.name, span.kind,
+// status.code) where status.code is one of STATUS_CODE_OK,
+// STATUS_CODE_ERROR, STATUS_CODE_UNSET.
+//
+// Using these for the Home catalog and Service Detail RED charts is
+// orders of magnitude cheaper than raw-span aggregation at scale.
+// Accuracy trade-off: `percentile(_value, N)` on the duration metric
+// is percentile-of-means — the collector pre-computes a mean per
+// export interval so we're aggregating over those means, not raw
+// observations. Directionally correct, not perfectly accurate. For
+// true histogram percentiles we'd need to parse the cumulative
+// bucket map in `${name}_data._buckets`, tracked as a v2 in the
+// ROADMAP.
+//
+// Counter rate semantics: rate over the window is derived from
+// `max(_value) - min(_value)` divided by the window length, with
+// resets handled by a max() aggregation (resets would make min()
+// spuriously low but the max-min difference stays close to the
+// true count unless the counter was reset DURING the window).
+//
+// Unit note: the duration histogram is emitted in milliseconds;
+// multiply by 1000 at the API layer to match the existing
+// microsecond-based ServiceSummary / ServiceBucket contract.
+// ─────────────────────────────────────────────────────────────────
+
+/** Build the metric-select WHERE clause used by every spanmetrics
+ * query, optionally scoped to a single service. */
+function spanmetricsBase(metric: string, service?: string): string {
+  const svcFilter = service
+    ? `| where tostring(['service.name'])=="${service.replace(/"/g, '\\"')}"`
+    : '';
+  return `${metricsBase()}
+    | where _metric == "${metric}"
+    | extend svc=tostring(['service.name']),
+             op=tostring(['span.name']),
+             status=tostring(['status.code'])
+    ${svcFilter}`;
+}
+
+/**
+ * Per-service RED summary from spanmetrics. Returns the same shape
+ * as the raw-span serviceSummary() — svc, requests, errors,
+ * error_rate, p50/95/99 in microseconds — so callers can swap
+ * sources without changing transform code.
+ *
+ * IMPORTANT: the spanmetrics calls counter is emitted per
+ * (service.name, span.name, span.kind, status.code) time series, so
+ * we MUST compute the max/min delta per tuple and then sum. Merging
+ * all tuples into one group and then doing max(_value)-min(_value)
+ * at the service level over-counts massively because max picks the
+ * biggest counter from the highest-volume op while min picks the
+ * smallest from a low-volume op, and the difference has no real
+ * meaning.
+ */
+export function spanmetricsServiceSummary(service?: string): string {
+  const svcFilter = service
+    ? `| where tostring(['service.name'])=="${service.replace(/"/g, '\\"')}"`
+    : '';
+  // Calls side: per-tuple deltas, then sum per service. `coalesce`
+  // the error count so services with zero errors land at 0 instead
+  // of the null that `sumif` returns on empty input.
+  const calls = `${metricsBase()}
+    | where _metric == "traces.span.metrics.calls"
+    | extend svc=tostring(['service.name']),
+             op=tostring(['span.name']),
+             status=tostring(['status.code'])
+    ${svcFilter}
+    | summarize delta=max(toreal(_value))-min(toreal(_value))
+      by svc, op, status
+    | summarize requests=sum(delta),
+                errors_raw=sumif(delta, status=="STATUS_CODE_ERROR")
+      by svc
+    | extend errors=iff(isnull(errors_raw), 0.0, toreal(errors_raw))
+    | extend error_rate=iff(requests>0, errors/toreal(requests), 0.0)`;
+  // Duration side — percentile-of-means on the histogram's _value
+  // (which is the per-export mean the spanmetrics connector computes).
+  // We multiply by 1000 to convert ms → µs.
+  const duration = `${metricsBase()}
+    | where _metric == "traces.span.metrics.duration"
+    | extend svc=tostring(['service.name'])
+    ${svcFilter}
+    | summarize p50_us=percentile(toreal(_value), 50)*1000,
+                p95_us=percentile(toreal(_value), 95)*1000,
+                p99_us=percentile(toreal(_value), 99)*1000
+      by svc`;
+  return `${calls}
+    | join kind=leftouter (${duration}) on svc
+    | project svc, requests, errors, error_rate, p50_us, p95_us, p99_us
+    | sort by requests desc`;
+}
+
+/**
+ * Per-service bucketed RED time series from spanmetrics. Shape
+ * matches the raw-span serviceTimeSeries() so existing transform
+ * code works unchanged.
+ *
+ * Rate per bucket = max(_value) - min(_value) within the bucket on
+ * the calls counter. Error counts are split out by status at the
+ * same bucket/svc grouping level.
+ */
+export function spanmetricsServiceTimeSeries(
+  binSeconds: number,
+  service?: string,
+): string {
+  const svcFilter = service
+    ? `| where tostring(['service.name'])=="${service.replace(/"/g, '\\"')}"`
+    : '';
+  // Per-tuple delta first so cross-operation counter values don't get
+  // conflated; then sum per (svc, bucket) and coalesce nulls.
+  const calls = `${metricsBase()}
+    | where _metric == "traces.span.metrics.calls"
+    | extend svc=tostring(['service.name']),
+             op=tostring(['span.name']),
+             status=tostring(['status.code'])
+    ${svcFilter}
+    | summarize delta=max(toreal(_value))-min(toreal(_value))
+      by svc, op, status, bucket=bin(_time, ${binSeconds}s)
+    | summarize requests=sum(delta),
+                errors_raw=sumif(delta, status=="STATUS_CODE_ERROR")
+      by svc, bucket
+    | extend errors=iff(isnull(errors_raw), 0.0, toreal(errors_raw))`;
+  const duration = `${metricsBase()}
+    | where _metric == "traces.span.metrics.duration"
+    | extend svc=tostring(['service.name'])
+    ${svcFilter}
+    | summarize p50_us=percentile(toreal(_value), 50)*1000,
+                p95_us=percentile(toreal(_value), 95)*1000,
+                p99_us=percentile(toreal(_value), 99)*1000
+      by svc, bucket=bin(_time, ${binSeconds}s)`;
+  return `${calls}
+    | join kind=leftouter (${duration}) on svc, bucket
+    | project svc, bucket, requests, errors, p50_us, p95_us, p99_us
+    | sort by svc asc, bucket asc`;
+}
+
+/**
+ * Per-operation RED for a single service from spanmetrics. Shape
+ * matches serviceOperations() so the Service Detail top-operations
+ * table works unchanged.
+ */
+export function spanmetricsServiceOperations(service: string): string {
+  const svc = service.replace(/"/g, '\\"');
+  // (name, status) is already the per-tuple granularity here since
+  // we're scoped to one service — one span.name with one status
+  // value is a single time series. Coalesce null errors to 0.
+  const calls = `${metricsBase()}
+    | where _metric == "traces.span.metrics.calls"
+    | extend svc=tostring(['service.name']),
+             name=tostring(['span.name']),
+             status=tostring(['status.code'])
+    | where svc=="${svc}"
+    | summarize delta=max(toreal(_value))-min(toreal(_value))
+      by name, status
+    | summarize requests=sum(delta),
+                errors_raw=sumif(delta, status=="STATUS_CODE_ERROR")
+      by name
+    | extend errors=iff(isnull(errors_raw), 0.0, toreal(errors_raw))
+    | extend error_rate=iff(requests>0, errors/toreal(requests), 0.0)`;
+  const duration = `${metricsBase()}
+    | where _metric == "traces.span.metrics.duration"
+    | extend svc=tostring(['service.name']),
+             name=tostring(['span.name'])
+    | where svc=="${svc}"
+    | summarize p50_us=percentile(toreal(_value), 50)*1000,
+                p95_us=percentile(toreal(_value), 95)*1000,
+                p99_us=percentile(toreal(_value), 99)*1000
+      by name`;
+  return `${calls}
+    | join kind=leftouter (${duration}) on name
+    | project name, requests, errors, error_rate, p50_us, p95_us, p99_us
+    | sort by requests desc
+    | limit 50`;
+}
+
+/**
+ * Presence probe: returns one row if the spanmetrics connector is
+ * feeding the dataset. Called once at startup and cached so later
+ * queries don't have to re-detect.
+ */
+export function spanmetricsPresence(): string {
+  return `${metricsBase()}
+    | where _metric == "traces.span.metrics.calls"
+    | limit 1
+    | project _metric`;
+}
+
+// Silence unused-export lint for the helper that's only used from
+// within this module — keeping spanmetricsBase as a hook for
+// future cards that want to extend the spanmetrics query pattern.
+void spanmetricsBase;
+
+// ─────────────────────────────────────────────────────────────────
+// Service Detail: protocol / runtime / infra cards
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * List every metric the given service emits. Drives the
+ * auto-detection logic for the Service Detail cards — we don't
+ * want to query a protocol/runtime/infra metric if the service
+ * isn't emitting it. Scoped by both `service.name` and
+ * `k8s.deployment.name` so the k8s-cluster-receiver metrics
+ * (which don't set service.name) are also picked up.
+ *
+ * Note: Cribl KQL doesn't accept `tostring(...)==X or tostring(...)==Y`
+ * inline — it can't parse the OR of two function expressions. We
+ * have to `extend` the columns first, then filter. Same pattern
+ * in the other per-service queries below.
+ */
+export function listServiceMetrics(service: string): string {
+  const s = service.replace(/"/g, '\\"');
+  return `${metricsBase()}
+    | extend svc=tostring(['service.name']),
+             dep=tostring(['k8s.deployment.name'])
+    | where svc == "${s}" or dep == "${s}"
+    | summarize samples=count() by _metric
+    | sort by samples desc
+    | limit 500`;
+}
+
+/**
+ * Latest-value query for a single metric scoped to a service.
+ * Uses the same service-name-or-k8s-deployment-name fallback as
+ * listServiceMetrics so k8s cluster metrics (which have null
+ * service.name) still correlate back to app services by deployment
+ * name. Returns one row with the most recent _value in the window.
+ */
+export function serviceMetricLatest(
+  service: string,
+  metric: string,
+): string {
+  const s = service.replace(/"/g, '\\"');
+  const m = metric.replace(/"/g, '\\"');
+  return `${metricsBase()}
+    | where _metric == "${m}"
+    | extend svc=tostring(['service.name']),
+             dep=tostring(['k8s.deployment.name'])
+    | where svc == "${s}" or dep == "${s}"
+    | sort by _time desc
+    | limit 1
+    | project val=toreal(_value)`;
+}
+
+/**
+ * Delta query for a cumulative counter scoped to a service over
+ * the current window. Used by the "restarts in the window" display
+ * where what matters is "did this number change" not "what is the
+ * lifetime value". Per-time-series delta (by pod/container) to
+ * avoid the same mis-aggregation bug spanmetrics hit.
+ */
+export function serviceMetricDelta(
+  service: string,
+  metric: string,
+): string {
+  const s = service.replace(/"/g, '\\"');
+  const m = metric.replace(/"/g, '\\"');
+  return `${metricsBase()}
+    | where _metric == "${m}"
+    | extend svc=tostring(['service.name']),
+             dep=tostring(['k8s.deployment.name']),
+             pod=tostring(['k8s.pod.name']),
+             container=tostring(['k8s.container.name'])
+    | where svc == "${s}" or dep == "${s}"
+    | summarize d=max(toreal(_value))-min(toreal(_value))
+      by pod, container
+    | summarize delta=sum(d)`;
+}
+
+/**
+ * Time-series for a service metric with the same service matching
+ * fallback as listServiceMetrics. Used by the runtime/infra/protocol
+ * cards to populate their sparklines. Returns (bucket, val) rows
+ * where val is percentile(_value, 95) for histogram-like metrics,
+ * or the aggregation the caller picks.
+ */
+export function serviceMetricTimeSeries(
+  service: string,
+  metric: string,
+  binSeconds: number,
+  agg: 'avg' | 'max' | 'p95' = 'p95',
+): string {
+  const s = service.replace(/"/g, '\\"');
+  const m = metric.replace(/"/g, '\\"');
+  let aggExpr: string;
+  if (agg === 'p95') {
+    aggExpr = 'percentile(toreal(_value), 95)';
+  } else if (agg === 'max') {
+    aggExpr = 'max(toreal(_value))';
+  } else {
+    aggExpr = 'avg(toreal(_value))';
+  }
+  return `${metricsBase()}
+    | where _metric == "${m}"
+    | extend svc=tostring(['service.name']),
+             dep=tostring(['k8s.deployment.name'])
+    | where svc == "${s}" or dep == "${s}"
+    | summarize val=${aggExpr} by bucket=bin(_time, ${binSeconds}s)
+    | sort by bucket asc`;
+}
+
+/**
+ * Batched time-series: fetch (metric, bucket) → value for multiple
+ * metrics in a single query. Used by the Service Detail page to
+ * collapse 15+ per-row fetches on the Protocol/Runtime/Infrastructure
+ * cards into one round trip. Saturating the Cribl search worker pool
+ * with per-row fetches queued each request for 30+ seconds behind
+ * the others; batching eliminates that entirely.
+ *
+ * Returns rows shaped as (metric, bucket, val), where val is
+ * percentile(_value, 95) — a reasonable default for both histograms
+ * (the spanmetrics/OTel histograms report means, so p95-of-means is
+ * effectively max-of-means) and gauges (p95 of a gauge is close to
+ * its peak). Callers that need a different aggregation per metric
+ * can still fire the single-metric query.
+ */
+export function serviceMetricsBatch(
+  service: string,
+  metrics: string[],
+  binSeconds: number,
+): string {
+  const s = service.replace(/"/g, '\\"');
+  // Dedupe + quote-escape
+  const metricList = Array.from(new Set(metrics))
+    .map((m) => `"${m.replace(/"/g, '\\"')}"`)
+    .join(', ');
+  return `${metricsBase()}
+    | where _metric in (${metricList})
+    | extend svc=tostring(['service.name']),
+             dep=tostring(['k8s.deployment.name'])
+    | where svc == "${s}" or dep == "${s}"
+    | summarize val=percentile(toreal(_value), 95)
+      by metric=_metric, bucket=bin(_time, ${binSeconds}s)
+    | sort by metric asc, bucket asc`;
+}

--- a/oteldemo/src/api/search.ts
+++ b/oteldemo/src/api/search.ts
@@ -147,9 +147,12 @@ function toObject(v: unknown): Record<string, unknown> {
 }
 
 /**
- * Fetch the per-service rollup. When `service` is provided, the query
- * is pre-filtered to that service at the KQL level — a big speedup on
- * Service Detail (see serviceSummary() docstring).
+ * Fetch the per-service rollup. Raw-span aggregation — the
+ * spanmetrics-backed path was tried but omitting the long-poll /
+ * idle-wait stream filter distorted percentile-of-means latencies
+ * (any service with a streaming gRPC endpoint showed 500s+ p95).
+ * Raw spans get the stream filter, which is the source of truth
+ * for latency percentiles.
  */
 export async function listServiceSummaries(
   earliest = '-1h',
@@ -172,14 +175,21 @@ export async function listServiceSummaries(
   });
 }
 
-/** Fetch time-bucketed per-service aggregates. */
+/**
+ * Fetch time-bucketed per-service aggregates.
+ */
 export async function getServiceTimeSeries(
   binSeconds: number,
   service?: string,
   earliest = '-1h',
   latest = 'now',
 ): Promise<ServiceBucket[]> {
-  const rows = await runQuery(Q.serviceTimeSeries(binSeconds, service), earliest, latest, 10000);
+  const rows = await runQuery(
+    Q.serviceTimeSeries(binSeconds, service),
+    earliest,
+    latest,
+    10000,
+  );
   return rows.map((r) => ({
     service: String(r.svc ?? 'unknown'),
     // bin(_time, Ns) returns a "bucket" column; the Cribl engine sometimes
@@ -193,7 +203,11 @@ export async function getServiceTimeSeries(
   }));
 }
 
-/** Fetch operations for a service, sorted by volume. */
+/**
+ * Fetch operations for a service, sorted by volume. Raw-span
+ * aggregation — see listServiceSummaries() for why spanmetrics
+ * isn't used here.
+ */
 export async function listOperationSummaries(
   service: string,
   earliest = '-1h',
@@ -447,6 +461,135 @@ export async function listMetricServices(
   if (!metric) return [];
   const rows = await runQuery(Q.metricServices(metric), earliest, latest, 500);
   return rows.map((r) => String(r.svc)).filter(Boolean);
+}
+
+/**
+ * List every metric a given service emits (or has cluster-level k8s
+ * metrics for). Drives the auto-detection logic for the Protocol /
+ * Runtime / Infra cards on Service Detail.
+ */
+export async function listServiceMetricNames(
+  service: string,
+  earliest = '-1h',
+  latest = 'now',
+): Promise<string[]> {
+  if (!service) return [];
+  const rows = await runQuery(
+    Q.listServiceMetrics(service),
+    earliest,
+    latest,
+    500,
+  );
+  return rows.map((r) => String(r._metric ?? '')).filter(Boolean);
+}
+
+/**
+ * Latest scalar value for a metric scoped to a service. Returns
+ * undefined if the metric has no samples in the window. Used by
+ * the Service Detail cards for "current memory usage", "ready
+ * state", etc.
+ */
+export async function getServiceMetricLatest(
+  service: string,
+  metric: string,
+  earliest = '-1h',
+  latest = 'now',
+): Promise<number | undefined> {
+  if (!service || !metric) return undefined;
+  const rows = await runQuery(
+    Q.serviceMetricLatest(service, metric),
+    earliest,
+    latest,
+    1,
+  );
+  if (rows.length === 0) return undefined;
+  const v = toNum(rows[0].val);
+  return Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Cumulative-counter delta for a service over the window. Used
+ * by the Infrastructure card's restart counter display — "how many
+ * restarts in the last hour" is the actionable number, not the
+ * lifetime count.
+ */
+export async function getServiceMetricDelta(
+  service: string,
+  metric: string,
+  earliest = '-1h',
+  latest = 'now',
+): Promise<number> {
+  if (!service || !metric) return 0;
+  const rows = await runQuery(
+    Q.serviceMetricDelta(service, metric),
+    earliest,
+    latest,
+    1,
+  );
+  if (rows.length === 0) return 0;
+  const v = toNum(rows[0].delta);
+  return Number.isFinite(v) ? v : 0;
+}
+
+/**
+ * Single-query batch fetch of per-service sparklines for many
+ * metrics at once. Returns a Map keyed by metric name with sorted
+ * (t, v) series. The Service Detail Protocol/Runtime/Infrastructure
+ * cards share one call instead of firing one query per row, which
+ * was the main cause of a 30+ second Service Detail load time under
+ * the previous implementation (every extra row queued behind the
+ * others in the search worker pool).
+ */
+export async function getServiceMetricsBatch(
+  service: string,
+  metrics: string[],
+  binSeconds: number,
+  earliest = '-1h',
+  latest = 'now',
+): Promise<Map<string, Array<{ t: number; v: number }>>> {
+  const out = new Map<string, Array<{ t: number; v: number }>>();
+  if (!service || metrics.length === 0) return out;
+  const rows = await runQuery(
+    Q.serviceMetricsBatch(service, metrics, binSeconds),
+    earliest,
+    latest,
+    5000,
+  );
+  for (const r of rows) {
+    const m = String(r.metric ?? '');
+    if (!m) continue;
+    if (!out.has(m)) out.set(m, []);
+    out.get(m)!.push({ t: toNum(r.bucket) * 1000, v: toNum(r.val) });
+  }
+  for (const series of out.values()) series.sort((a, b) => a.t - b.t);
+  return out;
+}
+
+/**
+ * Time-series for a service metric — drives sparklines in the
+ * Service Detail cards. Default agg is p95 which makes sense for
+ * the histogram metrics (http/rpc/db/jvm-gc durations) most of
+ * these cards show; callers can override for gauges where max or
+ * avg is more meaningful.
+ */
+export async function getServiceMetricSeries(
+  service: string,
+  metric: string,
+  binSeconds: number,
+  agg: 'avg' | 'max' | 'p95' = 'p95',
+  earliest = '-1h',
+  latest = 'now',
+): Promise<Array<{ t: number; v: number }>> {
+  if (!service || !metric) return [];
+  const rows = await runQuery(
+    Q.serviceMetricTimeSeries(service, metric, binSeconds, agg),
+    earliest,
+    latest,
+    1000,
+  );
+  return rows
+    .map((r) => ({ t: toNum(r.bucket) * 1000, v: toNum(r.val) }))
+    .sort((a, b) => a.t - b.t);
 }
 
 /**

--- a/oteldemo/src/components/MetricsCard.module.css
+++ b/oteldemo/src/components/MetricsCard.module.css
@@ -1,0 +1,97 @@
+.card {
+  background: var(--cds-color-bg);
+  border: 1px solid var(--cds-color-border-subtle);
+  border-radius: var(--cds-radius-lg);
+  box-shadow: var(--cds-shadow-sm);
+  overflow: hidden;
+}
+
+.header {
+  padding: var(--cds-space-sm) var(--cds-space-lg);
+  border-bottom: 1px solid var(--cds-color-border-subtle);
+  background: var(--cds-color-bg-subtle);
+}
+.title {
+  font-size: var(--cds-font-size-sm);
+  font-weight: var(--cds-font-weight-semibold);
+  color: var(--cds-color-fg);
+}
+.subtitle {
+  margin-top: 2px;
+  font-size: var(--cds-font-size-xs);
+  color: var(--cds-color-fg-muted);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: var(--cds-space-md);
+  padding: 6px var(--cds-space-lg);
+  border-bottom: 1px solid var(--cds-color-border-subtle);
+  font-size: var(--cds-font-size-sm);
+}
+.row:last-child {
+  border-bottom: none;
+}
+
+.rowLabel {
+  color: var(--cds-color-fg-muted);
+  font-size: var(--cds-font-size-xs);
+  font-weight: var(--cds-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rowValue {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--cds-font-weight-semibold);
+  color: var(--cds-color-fg);
+  white-space: nowrap;
+}
+.rowValueWarn {
+  color: var(--cds-color-danger);
+}
+.rowLoading {
+  color: var(--cds-color-fg-subtle);
+  font-style: italic;
+}
+
+.rowSpark {
+  display: flex;
+  align-items: center;
+}
+
+/* Match the opsCard skeleton on Service Detail so all cards feel
+   unified while data is in flight. */
+.skeletonRows {
+  padding: var(--cds-space-lg);
+}
+.skeletonRows > div {
+  height: 14px;
+  margin-bottom: 10px;
+  background: linear-gradient(
+    90deg,
+    var(--cds-color-bg-muted) 0%,
+    var(--cds-color-bg-subtle) 50%,
+    var(--cds-color-bg-muted) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--cds-radius-sm);
+  animation: mc-shimmer 1.4s linear infinite;
+}
+.skeletonRows > div:last-child {
+  margin-bottom: 0;
+}
+@keyframes mc-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/oteldemo/src/components/MetricsCard.tsx
+++ b/oteldemo/src/components/MetricsCard.tsx
@@ -1,0 +1,281 @@
+/**
+ * Reusable card used by the Service Detail Protocol / Runtime /
+ * Infrastructure sections. Config-driven: the caller passes a list
+ * of metric rows, each row specifies a label, one or more candidate
+ * metric names (first-match wins to handle old/new semconv
+ * variants), an aggregation, and an optional unit formatter. The
+ * card auto-fetches the latest value and a sparkline for each row,
+ * hides rows whose metrics don't exist for the current service, and
+ * hides itself entirely if no rows survive detection.
+ *
+ * The filter-before-render pattern is what lets one card work for
+ * a Python service, a JVM service, and a Node service — the
+ * Runtime card lists jvm.*, process.runtime.cpython.*, and
+ * process.runtime.go.* rows, and each service only shows the
+ * subset it emits.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import Sparkline from './Sparkline';
+import { getServiceMetricDelta } from '../api/search';
+import s from './MetricsCard.module.css';
+
+/** One row in a metrics card. */
+export interface MetricsCardRow {
+  /** Human label shown on the left. */
+  label: string;
+  /**
+   * One or more candidate metric names. The first one that has data
+   * wins — this is how we support old vs new OTel semconv variants
+   * like `http.client.duration` (old) vs `http.client.request.duration`
+   * (new) without the caller having to know which one a given
+   * service's instrumentation emits.
+   */
+  metric: string | string[];
+  /** How to fetch the current value. */
+  fetch?: 'latest' | 'delta';
+  /** Aggregation for the sparkline time series. */
+  agg?: 'avg' | 'max' | 'p95';
+  /** Format the scalar for display. Receives the raw metric value. */
+  format?: (v: number) => string;
+  /** Show this row as a warning (red) when the value is above/below a threshold. */
+  warn?: (v: number) => boolean;
+  /** Hide the sparkline on this row — used for stats that don't vary meaningfully. */
+  noSparkline?: boolean;
+}
+
+interface Props {
+  /** Title shown at the top of the card. */
+  title: string;
+  /** Short subtitle / hint. */
+  subtitle?: string;
+  /** Candidate rows. Each is conditionally rendered based on data. */
+  rows: MetricsCardRow[];
+  /** Scoped to this service. */
+  service: string;
+  /** Time range, shared with the rest of the Service Detail page. */
+  range: string;
+  /**
+   * Pre-fetched list of metric names that exist for this service,
+   * or `undefined` while still loading. When undefined, the card
+   * renders its skeleton state. When a Set, rows whose candidate
+   * metrics aren't present are filtered out (and if zero rows
+   * survive, the card hides itself).
+   */
+  availableMetrics?: Set<string>;
+  /**
+   * Pre-fetched series data for all metrics the card might show,
+   * or `undefined` while still loading. The Service Detail page
+   * loads this in a single batched query and passes the same Map
+   * to every card so all three cards share one round trip.
+   */
+  seriesByMetric?: Map<string, Array<{ t: number; v: number }>>;
+}
+
+interface RowData {
+  row: MetricsCardRow;
+  /** Which candidate metric name resolved for this row. */
+  resolvedMetric: string;
+  value: number | undefined;
+  series: Array<{ t: number; v: number }>;
+  loading: boolean;
+}
+
+/** Short number formatter — used by default when a row doesn't pass
+ * its own format function. */
+function defaultFormat(v: number): string {
+  if (!Number.isFinite(v)) return '—';
+  if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(2)}B`;
+  if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(2)}M`;
+  if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(1)}k`;
+  return v.toFixed(v < 10 ? 2 : 0);
+}
+
+export default function MetricsCard({
+  title,
+  subtitle,
+  rows,
+  service,
+  range,
+  availableMetrics,
+  seriesByMetric,
+}: Props) {
+  // Resolve each row's metric to the first candidate that exists for
+  // this service (if we have the catalog). Rows whose metric isn't
+  // available are dropped up front.
+  const resolvedRows = useMemo(() => {
+    return rows
+      .map((row) => {
+        const candidates = Array.isArray(row.metric) ? row.metric : [row.metric];
+        const resolved = availableMetrics
+          ? candidates.find((name) => availableMetrics.has(name))
+          : candidates[0];
+        return resolved ? { row, resolvedMetric: resolved } : null;
+      })
+      .filter((x): x is { row: MetricsCardRow; resolvedMetric: string } => x !== null);
+  }, [rows, availableMetrics]);
+
+  const [rowData, setRowData] = useState<RowData[]>([]);
+
+  useEffect(() => {
+    if (!service || resolvedRows.length === 0) {
+      setRowData([]);
+      return;
+    }
+    let cancelled = false;
+
+    // Seed latest-kind rows from the batched series map immediately
+    // (no extra round trip); `delta` rows still need their own
+    // delta query. `seriesByMetric` might be undefined on the first
+    // render before the page-level batch fetch resolves — in that
+    // case rows stay in a loading state.
+    const latestRows: RowData[] = resolvedRows.map(({ row, resolvedMetric }) => {
+      const fetchKind = row.fetch ?? 'latest';
+      if (fetchKind === 'delta') {
+        return {
+          row,
+          resolvedMetric,
+          value: undefined,
+          series: [],
+          loading: true,
+        };
+      }
+      const series = seriesByMetric?.get(resolvedMetric) ?? [];
+      const last = series.length > 0 ? series[series.length - 1].v : undefined;
+      return {
+        row,
+        resolvedMetric,
+        value: last,
+        series: row.noSparkline ? [] : series,
+        loading: !seriesByMetric,
+      };
+    });
+    setRowData(latestRows);
+
+    // Fire delta queries in parallel for any delta-kind rows. These
+    // are few (k8s.container.restarts, python.gc_count) and don't
+    // need to be batched.
+    const deltaTasks = resolvedRows
+      .map(({ row, resolvedMetric }, idx) => ({ row, resolvedMetric, idx }))
+      .filter(({ row }) => (row.fetch ?? 'latest') === 'delta');
+
+    if (deltaTasks.length > 0) {
+      Promise.all(
+        deltaTasks.map(async ({ row, resolvedMetric, idx }) => {
+          try {
+            const scalar = await getServiceMetricDelta(
+              service,
+              resolvedMetric,
+              range,
+              'now',
+            );
+            return { idx, row, resolvedMetric, scalar };
+          } catch {
+            return { idx, row, resolvedMetric, scalar: 0 };
+          }
+        }),
+      ).then((results) => {
+        if (cancelled) return;
+        setRowData((prev) => {
+          const next = [...prev];
+          for (const { idx, row, resolvedMetric, scalar } of results) {
+            const series = row.noSparkline
+              ? []
+              : (seriesByMetric?.get(resolvedMetric) ?? []);
+            next[idx] = {
+              row,
+              resolvedMetric,
+              value: scalar,
+              series,
+              loading: false,
+            };
+          }
+          return next;
+        });
+      });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [service, range, resolvedRows, seriesByMetric]);
+
+  // While the catalog or the batched series data is still in
+  // flight, render a skeleton that matches the opsCard style used
+  // by the other cards on Service Detail. We can't decide whether
+  // to hide the card yet — that only makes sense once we know
+  // which rows actually have data.
+  const isLoading = !availableMetrics || !seriesByMetric;
+
+  if (isLoading) {
+    return (
+      <div className={s.card}>
+        <div className={s.header}>
+          <div className={s.title}>{title}</div>
+          {subtitle && <div className={s.subtitle}>{subtitle}</div>}
+        </div>
+        <div className={s.skeletonRows}>
+          {[82, 72, 88].map((w, i) => (
+            <div key={i} style={{ width: `${w}%` }} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // A row is "present" if it has a finite value OR a non-empty series.
+  // If nothing lands for any row, hide the card entirely so empty
+  // sections don't clutter Service Detail.
+  const presentRows = rowData.filter(
+    (r) =>
+      (typeof r.value === 'number' && Number.isFinite(r.value)) ||
+      r.series.length > 0,
+  );
+
+  if (resolvedRows.length === 0) return null;
+  if (!rowData.some((r) => r.loading) && presentRows.length === 0) return null;
+
+  return (
+    <div className={s.card}>
+      <div className={s.header}>
+        <div className={s.title}>{title}</div>
+        {subtitle && <div className={s.subtitle}>{subtitle}</div>}
+      </div>
+      <div className={s.rows}>
+        {rowData.map((r) => {
+          const hasValue =
+            typeof r.value === 'number' && Number.isFinite(r.value);
+          const hasSeries = r.series.length > 0;
+          if (!r.loading && !hasValue && !hasSeries) return null;
+          const fmt = r.row.format ?? defaultFormat;
+          const valText = hasValue ? fmt(r.value as number) : '—';
+          const isWarn =
+            hasValue && r.row.warn ? r.row.warn(r.value as number) : false;
+          return (
+            <div key={r.resolvedMetric} className={s.row}>
+              <div className={s.rowLabel}>{r.row.label}</div>
+              <div className={`${s.rowValue} ${isWarn ? s.rowValueWarn : ''}`}>
+                {r.loading ? (
+                  <span className={s.rowLoading}>…</span>
+                ) : (
+                  valText
+                )}
+              </div>
+              {!r.row.noSparkline && hasSeries && (
+                <div className={s.rowSpark}>
+                  <Sparkline
+                    data={r.series}
+                    width={120}
+                    height={22}
+                    color={isWarn ? '#dc2626' : 'var(--cds-color-accent)'}
+                    strokeWidth={1.5}
+                    ariaLabel={`${r.row.label} sparkline`}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/oteldemo/src/routes/ServiceDetailPage.module.css
+++ b/oteldemo/src/routes/ServiceDetailPage.module.css
@@ -111,6 +111,26 @@
   }
 }
 
+/* -------- Metric-backed cards row: protocol / runtime / infra -------- */
+
+.metricCards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--cds-space-lg);
+  margin-top: var(--cds-space-lg);
+  align-items: start;
+}
+@media (max-width: 1300px) {
+  .metricCards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+@media (max-width: 900px) {
+  .metricCards {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* -------- Lower grid: ops table + errors + deps -------- */
 
 .grid {

--- a/oteldemo/src/routes/ServiceDetailPage.tsx
+++ b/oteldemo/src/routes/ServiceDetailPage.tsx
@@ -5,12 +5,15 @@ import { binSecondsFor } from '../components/timeRanges';
 import LineChart, { type LineSeries } from '../components/LineChart';
 import TraceBriefList from '../components/TraceBriefList';
 import StatusBanner from '../components/StatusBanner';
+import MetricsCard, { type MetricsCardRow } from '../components/MetricsCard';
 import {
   listServiceSummaries,
   getServiceTimeSeries,
   listOperationSummaries,
   listRecentErrorTraces,
   getDependencies,
+  listServiceMetricNames,
+  getServiceMetricsBatch,
 } from '../api/search';
 import { serviceColor } from '../utils/spans';
 import { previousWindow } from '../utils/timeRange';
@@ -30,6 +33,44 @@ const DEFAULT_RANGE = '-1h';
 
 /** See HomePage — same rationale. */
 const MIN_PREV_SAMPLES = 10;
+
+/**
+ * Static union of every candidate metric that any card might show.
+ * Used to issue a single batched series query at page load time
+ * in parallel with the catalog lookup — accepting a small amount
+ * of over-fetch for metrics the service doesn't actually emit, in
+ * exchange for firing both round trips concurrently. Keep in sync
+ * with the row configs below.
+ */
+const ALL_CARD_METRICS: string[] = [
+  // Protocol
+  'http.client.request.duration',
+  'http.client.duration',
+  'http.server.request.duration',
+  'http.server.duration',
+  'rpc.client.duration',
+  'rpc.server.duration',
+  'db.client.operation.duration',
+  'db.client.connection.count',
+  // Runtime
+  'jvm.memory.used',
+  'jvm.gc.duration',
+  'jvm.thread.count',
+  'jvm.cpu.recent_utilization',
+  'process.runtime.cpython.memory',
+  'process.runtime.cpython.cpu.utilization',
+  'process.runtime.cpython.gc_count',
+  'process.runtime.cpython.thread_count',
+  'process.cpu.utilization',
+  'process.memory.usage',
+  // Infrastructure
+  'k8s.container.restarts',
+  'k8s.container.ready',
+  'k8s.pod.phase',
+  'k8s.container.memory_limit',
+  'k8s.container.memory_request',
+  'k8s.container.cpu_limit',
+];
 
 function fmtUs(us: number): string {
   if (!Number.isFinite(us) || us === 0) return '—';
@@ -89,6 +130,20 @@ export default function ServiceDetailPage() {
   // Trigger a re-fetch when the Settings stream-filter toggle changes,
   // so the Recent errors panel doesn't keep stale server-filtered data.
   const streamFilterEnabled = useStreamFilterEnabled();
+  // Catalog of metrics this service emits (by name). Used by the
+  // Protocol / Runtime / Infrastructure cards to hide sections the
+  // service doesn't actually have data for, and to pick between old
+  // and new semconv metric names.
+  const [serviceMetricSet, setServiceMetricSet] = useState<
+    Set<string> | undefined
+  >(undefined);
+  // Pre-fetched series data for every metric the cards might show,
+  // loaded in a single batched query (instead of one query per row,
+  // which saturated the Cribl search worker pool and queued page
+  // loads for 30+ seconds).
+  const [cardSeriesByMetric, setCardSeriesByMetric] = useState<
+    Map<string, Array<{ t: number; v: number }>> | undefined
+  >(undefined);
 
   const fetchAll = useCallback(async () => {
     setError(null);
@@ -150,8 +205,275 @@ export default function ServiceDetailPage() {
     void fetchAll();
   }, [fetchAll]);
 
+  // Metric cards fire TWO queries in parallel: the catalog (which
+  // tells us which rows to render) and a single batched series
+  // fetch for every candidate metric (which feeds all sparklines).
+  // The batch query over-fetches a bit — it asks for metrics that
+  // may not exist for this service — but running both round trips
+  // concurrently cuts Service Detail load time meaningfully, and
+  // `_metric in (...)` is an indexed filter in Cribl so the over-
+  // fetch costs little. Client-side, we filter the resulting Map
+  // down to metrics that are also in the catalog.
+  useEffect(() => {
+    if (!serviceName) return;
+    let cancelled = false;
+    setServiceMetricSet(undefined);
+    setCardSeriesByMetric(undefined);
+    const binSeconds = binSecondsFor(range);
+    Promise.all([
+      listServiceMetricNames(serviceName, range, 'now').catch(() => [] as string[]),
+      getServiceMetricsBatch(
+        serviceName,
+        ALL_CARD_METRICS,
+        binSeconds,
+        range,
+        'now',
+      ).catch(() => new Map<string, Array<{ t: number; v: number }>>()),
+    ]).then(([list, map]) => {
+      if (cancelled) return;
+      setServiceMetricSet(new Set(list));
+      setCardSeriesByMetric(map);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [serviceName, range]);
+
   const color = serviceColor(serviceName);
   const rangeMinutes = relativeTimeMs(range) / 60_000;
+
+  // ─────────────────────────────────────────────────────────────
+  // Metrics card row configs (P2 / P3 / P4)
+  //
+  // Each card is declarative — the config lists every candidate
+  // metric the card might show. The MetricsCard component hides
+  // rows whose metrics don't exist in serviceMetricSet, so one
+  // config works across different runtimes and deployment targets.
+  //
+  // Formatters duplicate a little logic from MetricsPage's unit
+  // inference to keep this file self-contained. They could be
+  // lifted into utils/metrics if more callers need them.
+  // ─────────────────────────────────────────────────────────────
+
+  const fmtMs = (v: number) => (v >= 1000 ? `${(v / 1000).toFixed(2)} s` : `${v.toFixed(1)} ms`);
+  const fmtBytes = (v: number) => {
+    if (v >= 1e9) return `${(v / 1e9).toFixed(2)} GB`;
+    if (v >= 1e6) return `${(v / 1e6).toFixed(1)} MB`;
+    if (v >= 1e3) return `${(v / 1e3).toFixed(1)} KB`;
+    return `${v.toFixed(0)} B`;
+  };
+  const fmtPct = (v: number) => `${(v * 100).toFixed(1)}%`;
+  const fmtInt = (v: number) => v.toFixed(0);
+
+  /**
+   * P2: downstream dependency latencies. Picks up the OTel semconv
+   * HTTP / gRPC / DB client histograms emitted by instrumentation
+   * libraries. Old and new semconv names are grouped into one row
+   * (first match wins). A service only shows the subset of
+   * protocols it actually talks — e.g., a service with only RPC
+   * downstream shows one row, while a service with HTTP + DB shows
+   * two.
+   */
+  const protocolRows: MetricsCardRow[] = [
+    {
+      label: 'HTTP client p95',
+      metric: ['http.client.request.duration', 'http.client.duration'],
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'HTTP server p95',
+      metric: ['http.server.request.duration', 'http.server.duration'],
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'gRPC client p95',
+      metric: 'rpc.client.duration',
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'gRPC server p95',
+      metric: 'rpc.server.duration',
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'DB query p95',
+      metric: 'db.client.operation.duration',
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'DB connections',
+      metric: 'db.client.connection.count',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtInt,
+      noSparkline: true,
+    },
+  ];
+
+  /**
+   * P3: runtime health. JVM, Python (cpython), and generic process
+   * metrics all coexist in one config — the card picks whichever
+   * the service actually emits. Services running on the Node SDK
+   * wouldn't emit any of these, and the card would hide itself.
+   */
+  const runtimeRows: MetricsCardRow[] = [
+    // JVM
+    {
+      label: 'JVM memory used',
+      metric: 'jvm.memory.used',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtBytes,
+    },
+    {
+      label: 'JVM GC duration p95',
+      metric: 'jvm.gc.duration',
+      fetch: 'latest',
+      agg: 'p95',
+      format: fmtMs,
+    },
+    {
+      label: 'JVM threads',
+      metric: 'jvm.thread.count',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtInt,
+    },
+    {
+      label: 'JVM CPU',
+      metric: 'jvm.cpu.recent_utilization',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtPct,
+      warn: (v) => v > 0.8,
+    },
+    // Python cpython runtime
+    {
+      label: 'Python memory',
+      metric: 'process.runtime.cpython.memory',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtBytes,
+    },
+    {
+      label: 'Python CPU',
+      metric: 'process.runtime.cpython.cpu.utilization',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtPct,
+      warn: (v) => v > 0.8,
+    },
+    {
+      label: 'Python GC cycles',
+      metric: 'process.runtime.cpython.gc_count',
+      fetch: 'delta',
+      agg: 'max',
+      format: fmtInt,
+    },
+    {
+      label: 'Python threads',
+      metric: 'process.runtime.cpython.thread_count',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtInt,
+    },
+    // Generic process (covers Go / Node / anything that sets these)
+    {
+      label: 'Process CPU',
+      metric: 'process.cpu.utilization',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtPct,
+      warn: (v) => v > 0.8,
+    },
+    {
+      label: 'Process memory',
+      metric: 'process.memory.usage',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtBytes,
+    },
+  ];
+
+  /**
+   * P4: k8s / host infrastructure context. Only appears when the
+   * k8s cluster receiver or host metrics are feeding the dataset.
+   * Restarts fetch the delta in the window — the lifetime count is
+   * misleading; what matters is "did this number change". Memory
+   * limits/requests are gauges so we show the latest value.
+   */
+  const infraRows: MetricsCardRow[] = [
+    {
+      label: 'Restarts in window',
+      metric: 'k8s.container.restarts',
+      fetch: 'delta',
+      agg: 'max',
+      format: fmtInt,
+      warn: (v) => v > 0,
+      noSparkline: true,
+    },
+    {
+      label: 'Container ready',
+      metric: 'k8s.container.ready',
+      fetch: 'latest',
+      agg: 'avg',
+      format: (v) => (v >= 1 ? 'yes' : 'no'),
+      warn: (v) => v < 1,
+      noSparkline: true,
+    },
+    {
+      label: 'Pod phase',
+      metric: 'k8s.pod.phase',
+      fetch: 'latest',
+      agg: 'max',
+      // OTel k8s pod phase values: 1=pending, 2=running, 3=succeeded,
+      // 4=failed, 5=unknown. Treat anything other than running as warn.
+      format: (v) => {
+        if (v === 2) return 'running';
+        if (v === 1) return 'pending';
+        if (v === 4) return 'failed';
+        if (v === 3) return 'succeeded';
+        if (v === 5) return 'unknown';
+        return String(v);
+      },
+      warn: (v) => v !== 2,
+      noSparkline: true,
+    },
+    {
+      label: 'Memory limit',
+      metric: 'k8s.container.memory_limit',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtBytes,
+      noSparkline: true,
+    },
+    {
+      label: 'Memory request',
+      metric: 'k8s.container.memory_request',
+      fetch: 'latest',
+      agg: 'max',
+      format: fmtBytes,
+      noSparkline: true,
+    },
+    {
+      label: 'CPU limit',
+      metric: 'k8s.container.cpu_limit',
+      fetch: 'latest',
+      agg: 'max',
+      format: (v) => `${v.toFixed(2)} cores`,
+      noSparkline: true,
+    },
+  ];
 
   // Prepare chart series from buckets
   const chartSeries = useMemo(() => {
@@ -383,6 +705,41 @@ export default function ServiceDetailPage() {
           series={durSeries}
           yFormat={fmtUsAxis}
           emptyMessage={loadingBuckets ? 'Loading…' : 'No data'}
+        />
+      </div>
+
+      {/* Metric-backed cards: dependency latencies, runtime, infra.
+          Each card hides itself entirely when the service has no
+          data for any of its rows, so non-k8s services show two
+          cards, services without instrumented downstream calls
+          show one, and a fully-uninstrumented service shows none. */}
+      <div className={s.metricCards}>
+        <MetricsCard
+          title="Dependency latencies"
+          subtitle="p95 of outgoing calls by protocol"
+          rows={protocolRows}
+          service={serviceName}
+          range={range}
+          availableMetrics={serviceMetricSet}
+          seriesByMetric={cardSeriesByMetric}
+        />
+        <MetricsCard
+          title="Runtime health"
+          subtitle="Process / VM metrics from the instrumentation SDK"
+          rows={runtimeRows}
+          service={serviceName}
+          range={range}
+          availableMetrics={serviceMetricSet}
+          seriesByMetric={cardSeriesByMetric}
+        />
+        <MetricsCard
+          title="Infrastructure"
+          subtitle="Container + pod metrics from the k8s cluster receiver"
+          rows={infraRows}
+          service={serviceName}
+          range={range}
+          availableMetrics={serviceMetricSet}
+          seriesByMetric={cardSeriesByMetric}
         />
       </div>
 


### PR DESCRIPTION
**Adds Dependency latencies / Runtime health / Infrastructure metric cards to the Service Detail page, all fed by a single batched `getServiceMetricsBatch` query so the page doesn't fan out 15-30 per-row requests.**

## Commits
- `53aa74f` — Service Detail metric cards + batched fetch

## What's in it

- `MetricsCard.tsx` component with config-driven rows (metric-name, agg, format, warn thresholds)
- `serviceMetricsBatch()` KQL builder — single query returning `(metric, bucket, val)` for every candidate metric the three cards might show
- Service Detail row configs for: HTTP/gRPC/DB client latency (P2), JVM + process runtime (P3), k8s/cloud infra (P4)
- Metric cards auto-hide rows whose metrics aren't present for the current service — same config covers JVM / CPython / Node with no per-service branching

## Validate from your phone

Open the staging app, click any service (try `accounting` or `ad`):
- https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/service/accounting

Below the RED charts, three cards should render:
- **Dependency latencies** — HTTP client p95, DB query p95, DB connections
- **Runtime health** — process memory, CPU, GC (varies by service)
- **Infrastructure** — container metrics if k8s cluster receiver is up (may be hidden)

Cards should load within ~3 s (single batched query), not stagger in over 20 s (old per-row fan-out).

## Context

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)