### PR TITLE
oteldemo: kafka lag signal — traffic_drop health bucket + anomaly widget (parked)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,23 +76,114 @@ attribute filters and time-series plotting.
 This work may also benefit from a new query builder pattern the other
 features can reuse.
 
-### 2. Alerting + SLOs (via Cribl Saved Searches + alerts, no KQL exposed)
+### 2. Durable baselines, alerts, and SLOs (via scheduled Cribl Saved Searches)
 
-The single biggest reactive-to-proactive upgrade. For each of the
-primary objects the app shows (service, operation, edge, log stream),
-provide a "Create alert" affordance that:
+One shared infrastructure problem unblocks three features at once:
+durable baselines for anomaly detection, user-facing alerts, and SLO
+budget tracking. All three need the app to **provision scheduled
+Cribl Saved Searches** at install time (or on first run), keep them
+up-to-date across upgrades, and consume their persisted output.
 
-- Captures the current filter context (service, operation, severity,
-  range)
-- Asks for a threshold in plain terms ("error rate > 5%", "p95 > 2s",
-  "request rate drops by 50%")
-- Generates a KQL saved search behind the scenes
-- Creates a Cribl alert against that saved search
-- Stores app-level metadata (alert name, owning view, UI context) in
-  the pack-scoped KV so we can render a coherent "Alerts" page
+**Why this is now priority 2**: The current `listOperationAnomalies`
+baseline is a ~24h span-range query fired at page load. That's
+expensive (scans every span in 24h on every Home refresh), fragile
+(a multi-day incident poisons the baseline), and impossible to
+extend to week-over-week comparisons or seasonality. The only
+sustainable answer is a scheduled search that computes per-(svc, op)
+p50/p95/p99 on a rolling basis, persists the results somewhere
+queryable, and lets the UI read them cheaply.
 
-SLOs sit on top of the same plumbing — an SLO is an alert + budget
-tracking over a longer window, both expressible as saved searches.
+Same pattern, same plumbing works for alerts: "create alert" on a
+catalog row → app persists a new scheduled saved search + threshold
+evaluation, stores metadata so the Alerts page can render it. And
+for SLOs: a scheduled search that tracks error budget over a rolling
+28-day window.
+
+#### 2a. Research tasks (do these first — they determine the shape)
+
+- **Saved search provisioning API.** What Cribl Search REST endpoints
+  exist for creating / updating / deleting saved searches? What's the
+  auth context inside a Cribl App sandbox iframe — can the app make
+  authenticated calls to the control-plane API the same way it makes
+  KV calls, or is there a separate endpoint? Document the schema of a
+  saved search definition (query, schedule expression, output target).
+- **Scheduled-search execution model.** How does Cribl execute a
+  scheduled search? Where do the results land — in a dedicated
+  dataset, a KV key, an event table, something like Splunk's
+  `$vt_results$` summary indexing? How long are results retained?
+- **Result persistence target.** Three candidates worth comparing:
+  1. **Pack-scoped KV store** — cheapest, already in use for app
+     settings. Writable from both the app and presumably from a
+     scheduled search's output stage. Best for small results (a few
+     hundred baseline rows).
+  2. **Cribl lookups** — named tabular references that any KQL query
+     can join against. Best if baselines need to be queryable from
+     other saved searches.
+  3. **Dedicated `otel_baselines` dataset** — if Cribl Search supports
+     a scheduled search writing to a separate dataset, this scales
+     best and stays queryable without app mediation.
+- **Install-time hook on the Cribl App Platform.** Does the platform
+  support a "run this script when the pack is installed" hook (like a
+  Kubernetes operator or a Helm `post-install` job)? If yes, document
+  it and use it. If no, flag that as a **platform request** to the
+  Cribl team and design a first-run workflow instead.
+- **Idempotency + upgrade path.** How do we name provisioned searches
+  so we can find and update them on subsequent installs without
+  stomping user edits? Tag-based naming (`traceexplorer:baseline:op`)
+  feels right. How do we handle schema migrations when a new app
+  version needs a different baseline shape?
+
+#### 2b. Durable baseline for latency anomaly detection
+
+Replaces the in-memory 24h baseline in `listOperationAnomalies`:
+
+- A scheduled search runs every N minutes, computing per-(service,
+  operation) p50/p95/p99 over a rolling baseline window (7 days,
+  excluding the most recent hour so fresh incidents don't pollute
+  the baseline)
+- Results persist to the chosen target (KV / lookup / dataset)
+- The app reads the latest baseline row on page load — one cheap
+  lookup instead of a 24h span aggregation — and compares against
+  the current window
+- Gracefully degrades: if the baseline hasn't been populated yet
+  (first run, upgrade), fall back to the current in-memory 24h
+  approximation
+
+#### 2c. User-facing alerts
+
+- "Create alert" button on Home catalog rows, Service Detail, edges,
+  and logs — captures the current filter context and surfaces a
+  plain-language threshold form ("error rate > 5%", "p95 > 2s",
+  "request rate drops by 50%", "op p95 > N× baseline")
+- Under the hood the app generates a KQL saved search, creates a
+  Cribl alert against it via the same provisioning pipeline, and
+  stores app-level metadata (alert name, owning view, UI context)
+- Rendered on an "Alerts" page that lists all app-managed alerts,
+  their current state, recent firings, and a link back to the view
+  where they were created
+
+#### 2d. SLO budgets
+
+Thin layer on top of 2c. An SLO is a saved search that tracks
+(success count / total count) over a 28-day rolling window, plus a
+budget burn rate. Same provisioning plumbing, different threshold
+semantics and UI (error budget remaining, burn alerts at 1h / 6h /
+24h windows).
+
+#### 2e. First-run workflow + upgrade handling
+
+Assuming no install hook exists:
+
+- On first load, the app checks KV for a `provisioned-version` key
+- If absent or stale, show a one-time dialog: "Trace Explorer needs
+  to create N scheduled searches to power baselines and alerts.
+  [Create them]"
+- App calls the saved-search API with idempotent names; if a search
+  already exists, update it in place
+- Write `provisioned-version` to KV on success
+- On app upgrade, the same check runs: if stored version differs from
+  current, run the diff and update / add / remove scheduled searches
+  as needed. Never delete user-created searches.
 
 ### 3. Error tracking / Errors Inbox
 
@@ -232,28 +323,56 @@ As of the last commit on `jaeger-clone`:
 
 - Home: service catalog with rate / error / p50/p95/p99 columns, delta
   chips vs. previous window, error classes, slowest trace classes,
-  sortable columns
+  **latency anomalies widget** (ops ≥5× baseline p95), sortable columns
+- **Health buckets**: error-rate (watch/warn/critical) + `traffic_drop`
+  (rate fell ≥50% vs prior window) + `latency_anomaly` (op p95 ≥5×
+  baseline). Precedence: critical > warn > latency_anomaly >
+  traffic_drop > watch > healthy > idle. Row tints on Home catalog,
+  halo rings on System Architecture nodes.
 - Search: fixed-shape form with service / operation / tags / duration
   / limit / lookback; results table; stream-noise trace filter
   respected (via Settings toggle)
 - Logs: standalone log search tab with service / severity / body / limit
   / range filters; sticky facet sidebar; fills vertical viewport
+- Metrics: Datadog-style explorer tab with metric picker, group-by
+  dimensions, rate-of-counter derivation, histogram percentile from
+  means
 - Compare: two-trace structural diff
 - System Architecture: force-directed + isometric graphs, pan+zoom,
   edge-level health, messaging edges, node hover tooltip with
-  lazy-loaded operations breakdown, edge hover tooltip with rich card
+  lazy-loaded operations breakdown + traffic-drop delta, edge hover
+  tooltip with rich card
 - Service Detail: RED charts (rate, error, p50/p95/p99), top
-  operations, recent errors, dependencies, p99 delta chip
+  operations, recent errors, dependencies, p99 delta chip, **Dependency
+  latencies / Runtime health / Infrastructure metric cards** (batched
+  single query)
 - Trace detail: waterfall, span detail with attributes / events /
   logs / process tags / exception stack traces, trace logs tab
 - Settings: dataset selection + stream-filter toggle, persisted in
   pack-scoped KV
-- Infrastructure: CLAUDE.md, FAILURE-SCENARIOS.md reference,
-  scripts/flagd-set.sh helper for flipping demo flags
+- Infrastructure: CLAUDE.md, FAILURE-SCENARIOS.md reference, Cribl MCP
+  server wired via `.mcp.json`, scripts/flagd-set.sh helper,
+  scripts/cribl-mcp.sh container manager, browser automation helpers
 
 ## Next up
 
-**Metrics support** — see priority #1 above. First concrete step is
-to inspect the metric record schema in the `otel` dataset so we know
-what we're working with. Then build the query layer, then a Metrics
-tab in the navbar.
+**Durable baselines + alerts (priority #2)** — the in-memory 24h
+baseline now powering the latency-anomaly widget is a stopgap. The
+real answer is scheduled Cribl Saved Searches that persist rolling
+baselines the app can read cheaply. Start with the research tasks in
+2a (provisioning API, scheduled-search execution model, persistence
+target, install-time hook, idempotency) — those answers shape
+everything else. Once the shape is clear, build the first-run
+workflow in 2e, then migrate the anomaly detector in 2b off the
+in-memory baseline.
+
+Follow-up enhancements to the anomaly widget itself (after 2b lands):
+
+- **Reason pills on each row**: today every row shows one number
+  (ratio vs baseline). Add multi-heuristic tagging — ratio, absolute
+  p95, volume jump, error-rate delta, child-attribution anomaly —
+  so users can see *why* an op was flagged and disagree when needed.
+- **Per-op anomaly signal on Service Detail**: highlight the
+  individual row in the Top Operations table the same way the Home
+  catalog tints the service row, with a tooltip explaining the
+  baseline comparison.

--- a/oteldemo/src/api/queries.ts
+++ b/oteldemo/src/api/queries.ts
@@ -234,6 +234,33 @@ export function serviceOperations(service: string): string {
 }
 
 /**
+ * Per-(service, operation) latency summary across the full window —
+ * every op in the dataset, stream filter applied. Used by the
+ * latency-anomaly detector on the Home page: we run this twice
+ * (current window + prior window) and flag ops whose current p95
+ * is significantly higher than their baseline.
+ *
+ * The stream filter stays ON. Without it, the query's p95 would be
+ * dominated by idle-poll spans on consumer ops, which poisons both
+ * the anomaly signal and the baseline. Genuine latency anomalies
+ * still show up because the non-filtered portion of the spans
+ * (≤ 30s) still dwarfs the healthy baseline (~100ms for most ops).
+ */
+export function allOperationsSummary(limit: number = 1000): string {
+  return `${spansBase()}
+    | extend svc=tostring(resource.attributes['service.name']),
+            dur_us=(toreal(end_time_unix_nano)-toreal(start_time_unix_nano))/1000.0
+    ${streamFilterSpanKqlClause()}
+    | summarize requests=count(),
+                p50_us=percentile(dur_us, 50),
+                p95_us=percentile(dur_us, 95),
+                p99_us=percentile(dur_us, 99)
+      by svc, op=name
+    | sort by requests desc
+    | limit ${limit}`;
+}
+
+/**
  * Traces sorted by trace duration descending — "slow traces" panel on
  * the Home page. Optionally scoped to a service. Applies the same
  * long-poll / idle-wait filter as rawSlowestTraces() — see

--- a/oteldemo/src/api/search.ts
+++ b/oteldemo/src/api/search.ts
@@ -12,6 +12,7 @@ import type {
   ServiceSummary,
   ServiceBucket,
   OperationSummary,
+  OperationAnomaly,
   TraceBrief,
   TraceLogEntry,
   SlowTraceClass,
@@ -366,6 +367,100 @@ export async function listErrorClasses(
   }));
   classes.sort((a, b) => b.count - a.count || b.lastSeenMs - a.lastSeenMs);
   return classes.slice(0, topClasses);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Latency anomaly detection
+// ─────────────────────────────────────────────────────────────────
+
+/** Minimum baseline sample count for an op to be considered for
+ * anomaly scoring. Lower than the service-level traffic-drop gate
+ * because individual ops have lower volume. */
+const ANOMALY_MIN_BASELINE_REQUESTS = 20;
+
+/** Minimum ratio of curr p95 / prev p95 to flag as anomalous. 5× is
+ * large enough to filter out routine day-vs-day variance and small
+ * enough to catch consumer-side delay scenarios that push p95 from
+ * ~100ms to ~500ms+. */
+const ANOMALY_MIN_RATIO = 5;
+
+/** Absolute p95 floor — a 5× jump from 10ms to 50ms isn't actionable
+ * even if it technically qualifies. 1s of latency is the threshold
+ * at which a human would consider the operation "slow in absolute
+ * terms". */
+const ANOMALY_MIN_CURR_P95_US = 1_000_000;
+
+/**
+ * Per-op latency anomalies vs a long rolling baseline window. For
+ * every (service, operation) present in both windows, compute
+ * currP95 / baselineP95 and emit a row when the ratio crosses the
+ * threshold AND the current p95 exceeds the absolute floor AND the
+ * baseline window had enough samples to trust.
+ *
+ * Why the baseline is not the immediately-prior window: an ongoing
+ * incident that's been running for longer than the curr-window
+ * length would poison a same-length prior window too, and the ratio
+ * would sit at ~1× even though the op is clearly broken. A long
+ * rolling baseline (default 24h preceding curr) includes enough
+ * healthy history to survive multi-hour outages.
+ *
+ * Catches scenarios that absolute-duration ranking misses: e.g.,
+ * accounting.order-consumed at 18s p95 vs a healthy baseline of
+ * ~200ms (→ 90× ratio) won't show up on the Slowest Trace Classes
+ * widget because its absolute duration is smaller than a legitimate
+ * 60s image-load trace that's been streaming-filtered down to the
+ * upper bound.
+ *
+ * TODO: as part of the reason-pill redesign, also expose per-op
+ * error-rate delta, volume delta, and child-attribution delta so
+ * the widget can show WHY an op was flagged and the user can
+ * triage without opening Service Detail.
+ */
+export async function listOperationAnomalies(
+  earliest: string,
+  latest: string,
+  baselineEarliest: string,
+  baselineLatest: string,
+  topN: number = 20,
+): Promise<OperationAnomaly[]> {
+  const [currRows, baselineRows] = await Promise.all([
+    runQuery(Q.allOperationsSummary(), earliest, latest, 1000),
+    runQuery(Q.allOperationsSummary(), baselineEarliest, baselineLatest, 1000),
+  ]);
+  const baselineMap = new Map<string, { p95: number; count: number }>();
+  for (const r of baselineRows) {
+    const key = `${String(r.svc ?? '')}\u0000${String(r.op ?? '')}`;
+    baselineMap.set(key, {
+      p95: toNum(r.p95_us),
+      count: toNum(r.requests),
+    });
+  }
+  const anomalies: OperationAnomaly[] = [];
+  for (const r of currRows) {
+    const svc = String(r.svc ?? '');
+    const op = String(r.op ?? '');
+    if (!svc || !op) continue;
+    const key = `${svc}\u0000${op}`;
+    const baseline = baselineMap.get(key);
+    if (!baseline) continue;
+    if (baseline.count < ANOMALY_MIN_BASELINE_REQUESTS) continue;
+    const prevP95 = baseline.p95;
+    if (prevP95 <= 0) continue;
+    const currP95 = toNum(r.p95_us);
+    if (currP95 < ANOMALY_MIN_CURR_P95_US) continue;
+    const ratio = currP95 / prevP95;
+    if (ratio < ANOMALY_MIN_RATIO) continue;
+    anomalies.push({
+      service: svc,
+      operation: op,
+      currP95Us: currP95,
+      prevP95Us: prevP95,
+      ratio,
+      requests: toNum(r.requests),
+    });
+  }
+  anomalies.sort((a, b) => b.ratio - a.ratio);
+  return anomalies.slice(0, topN);
 }
 
 function percentile(values: number[], p: number): number {

--- a/oteldemo/src/api/types.ts
+++ b/oteldemo/src/api/types.ts
@@ -139,6 +139,32 @@ export interface SlowTraceClass {
   sampleTraceIDs: string[];
 }
 
+/**
+ * A per-operation latency anomaly — an operation whose current-window
+ * p95 is significantly higher than its immediately-prior window. Used
+ * to surface signals the absolute-duration "Slowest trace classes"
+ * widget misses: e.g., a consumer operation that normally runs in
+ * ~100ms now runs at 18s because of consumer-side delay injected by
+ * the kafka-queue-problems scenario.
+ *
+ * TODO: attach a list of "reasons" explaining why this was flagged —
+ * ratio vs baseline, absolute p95, volume jump, etc. — so the widget
+ * can show reason pills ("×90 baseline", "5s+ absolute"). Plumbing is
+ * in types/search/queries; the component just needs the extra fields.
+ */
+export interface OperationAnomaly {
+  service: string;
+  operation: string;
+  /** Current-window p95 duration in microseconds. */
+  currP95Us: number;
+  /** Prior-window p95 duration in microseconds — the baseline. */
+  prevP95Us: number;
+  /** currP95Us / prevP95Us — how many times worse than baseline. */
+  ratio: number;
+  /** Current-window request count for this op. */
+  requests: number;
+}
+
 /** A class of errors: (service, operation, first-line-of-message). */
 export interface ErrorClass {
   service: string;

--- a/oteldemo/src/components/DependencyGraph.tsx
+++ b/oteldemo/src/components/DependencyGraph.tsx
@@ -45,6 +45,11 @@ import type {
 interface Props {
   edges: DependencyEdge[];
   services: Map<string, ServiceSummary>;
+  /** Previous-window summaries, keyed by service name. Enables the
+   * traffic-drop health signal — services whose request rate has
+   * fallen sharply vs baseline are promoted to the `traffic_drop`
+   * bucket in the halo + tooltip. */
+  prevServices?: Map<string, ServiceSummary>;
   bucketsByService: Map<string, ServiceBucket[]>;
   width: number;
   height: number;
@@ -57,6 +62,7 @@ const DRAG_THRESHOLD = 4;
 export default function DependencyGraph({
   edges,
   services,
+  prevServices,
   bucketsByService,
   width,
   height,
@@ -410,7 +416,8 @@ export default function DependencyGraph({
             const x = n.x ?? 0;
             const y = n.y ?? 0;
             const summary = services.get(n.id);
-            const health = serviceHealth(summary);
+            const prevSummary = prevServices?.get(n.id);
+            const health = serviceHealth(summary, prevSummary);
             const isFocused = focusId === n.id;
             const isPinned = pinned === n.id;
             const idColor = serviceColor(n.id);
@@ -419,6 +426,7 @@ export default function DependencyGraph({
             const haloRadius = r + haloGap;
             const haloWidth =
               health.bucket === 'critical' ? 3.5
+              : health.bucket === 'traffic_drop' ? 3
               : health.bucket === 'warn' ? 3
               : health.bucket === 'watch' ? 2
               : health.bucket === 'idle' ? 1
@@ -504,6 +512,7 @@ export default function DependencyGraph({
             <NodeTooltip
               service={focusNode.id}
               summary={services.get(focusNode.id)}
+              prevSummary={prevServices?.get(focusNode.id)}
               buckets={bucketsByService.get(focusNode.id) ?? []}
               pinned={pinned === focusNode.id}
               left={left}

--- a/oteldemo/src/components/IsometricGraph.tsx
+++ b/oteldemo/src/components/IsometricGraph.tsx
@@ -30,6 +30,8 @@ import type {
 interface Props {
   edges: DependencyEdge[];
   services: Map<string, ServiceSummary>;
+  /** Previous-window summaries — enables the traffic-drop signal. */
+  prevServices?: Map<string, ServiceSummary>;
   bucketsByService: Map<string, ServiceBucket[]>;
   width: number;
   height: number;
@@ -83,6 +85,7 @@ function unprojectPoint(
 export default function IsometricGraph({
   edges,
   services,
+  prevServices,
   bucketsByService,
   width,
   height,
@@ -526,7 +529,8 @@ export default function IsometricGraph({
           {sortedNodes.map((p) => {
             const n = p.node;
             const summary = services.get(n.id);
-            const health = serviceHealth(summary);
+            const prevSummary = prevServices?.get(n.id);
+            const health = serviceHealth(summary, prevSummary);
             const isFocused = focusId === n.id;
             const isPinned = pinned === n.id;
             const idColor = serviceColor(n.id);
@@ -545,6 +549,7 @@ export default function IsometricGraph({
             const haloRy = ry + haloGap * CYL_TOP_RY_RATIO * 2.5;
             const haloWidth =
               health.bucket === 'critical' ? 3.5
+              : health.bucket === 'traffic_drop' ? 3
               : health.bucket === 'warn' ? 3
               : health.bucket === 'watch' ? 2
               : health.bucket === 'idle' ? 1
@@ -661,6 +666,7 @@ export default function IsometricGraph({
             <NodeTooltip
               service={focusNode.id}
               summary={services.get(focusNode.id)}
+              prevSummary={prevServices?.get(focusNode.id)}
               buckets={bucketsByService.get(focusNode.id) ?? []}
               pinned={pinned === focusNode.id}
               left={left}

--- a/oteldemo/src/components/NodeTooltip.module.css
+++ b/oteldemo/src/components/NodeTooltip.module.css
@@ -94,6 +94,18 @@
   color: var(--cds-color-danger);
 }
 
+.statDelta {
+  font-size: var(--cds-font-size-xs);
+  font-weight: var(--cds-font-weight-medium);
+  color: var(--cds-color-fg-muted);
+}
+
+.statDeltaBad {
+  font-size: var(--cds-font-size-xs);
+  font-weight: var(--cds-font-weight-semibold);
+  color: #a855f7;
+}
+
 .sparkBlock {
   margin-top: var(--cds-space-sm);
 }

--- a/oteldemo/src/components/NodeTooltip.tsx
+++ b/oteldemo/src/components/NodeTooltip.tsx
@@ -26,6 +26,10 @@ import s from './NodeTooltip.module.css';
 interface Props {
   service: string;
   summary: ServiceSummary | undefined;
+  /** Previous-window summary used to detect traffic drops. When
+   * present and significant, the tooltip's health label is promoted
+   * to "Traffic down NN%" and a delta row is shown under Rate. */
+  prevSummary?: ServiceSummary;
   buckets: ServiceBucket[];
   pinned: boolean;
   left: number;
@@ -100,6 +104,7 @@ function fmtUs(us: number): string {
 export default function NodeTooltip({
   service,
   summary,
+  prevSummary,
   buckets,
   pinned,
   left,
@@ -108,7 +113,7 @@ export default function NodeTooltip({
   loadOperations,
   lookback,
 }: Props) {
-  const health = serviceHealth(summary);
+  const health = serviceHealth(summary, prevSummary);
 
   // Lazy-loaded operations breakdown. Cached at the module level so
   // re-hovering the same node is instant; debounced with a small
@@ -249,7 +254,28 @@ export default function NodeTooltip({
             <span className={s.statLabel}>Requests</span>
             <span className={s.statValue}>{summary.requests.toLocaleString()}</span>
             <span className={s.statLabel}>Rate</span>
-            <span className={s.statValue}>{fmtRate(reqPerMin)}</span>
+            <span className={s.statValue}>
+              {fmtRate(reqPerMin)}
+              {prevSummary && prevSummary.requests > 0 && (
+                <span
+                  className={
+                    summary.requests / prevSummary.requests <= 0.5
+                      ? s.statDeltaBad
+                      : s.statDelta
+                  }
+                >
+                  {' '}
+                  {(() => {
+                    const pct = Math.round(
+                      ((summary.requests - prevSummary.requests) /
+                        prevSummary.requests) *
+                        100,
+                    );
+                    return `${pct >= 0 ? '+' : ''}${pct}% vs prior`;
+                  })()}
+                </span>
+              )}
+            </span>
             <span className={s.statLabel}>Errors</span>
             <span
               className={`${s.statValue} ${summary.errorRate > 0 ? s.statValueErr : ''}`}

--- a/oteldemo/src/components/OperationAnomalyList.tsx
+++ b/oteldemo/src/components/OperationAnomalyList.tsx
@@ -1,0 +1,119 @@
+/**
+ * Latency anomaly widget shown on the Home page next to Slowest Trace
+ * Classes and Error Classes. Lists operations whose current-window
+ * p95 is ≥ N× the prior window's p95 — catches consumer-side delay,
+ * downstream regressions, and other "this was fine yesterday" signals
+ * that absolute-duration ranking misses.
+ *
+ * Each row click drills into Search, pre-filtered to (service,
+ * operation) so the user lands on actual traces to investigate.
+ *
+ * TODO: render "reason pills" on each row once multiple heuristics
+ * feed into the widget — ratio vs baseline, absolute p95, volume
+ * jump, error-rate delta — so the user can see *why* an op was
+ * flagged instead of having to trust a single scalar ratio.
+ */
+import { Link } from 'react-router-dom';
+import { serviceColor } from '../utils/spans';
+import type { OperationAnomaly } from '../api/types';
+import s from './TraceClassList.module.css';
+
+interface Props {
+  items: OperationAnomaly[];
+  loading?: boolean;
+  /** Current lookback string ("-1h"), forwarded to the Search deep
+   * link so the drill-through keeps the same window. */
+  lookback: string;
+}
+
+function fmtDurationUs(us: number): string {
+  if (!Number.isFinite(us) || us === 0) return '—';
+  if (us < 1000) return `${us.toFixed(0)} μs`;
+  if (us < 1_000_000) return `${(us / 1000).toFixed(1)} ms`;
+  return `${(us / 1_000_000).toFixed(2)} s`;
+}
+
+function fmtRatio(ratio: number): string {
+  if (!Number.isFinite(ratio)) return '—';
+  if (ratio >= 100) return `×${ratio.toFixed(0)}`;
+  if (ratio >= 10) return `×${ratio.toFixed(1)}`;
+  return `×${ratio.toFixed(2)}`;
+}
+
+export default function OperationAnomalyList({ items, loading, lookback }: Props) {
+  return (
+    <div className={s.wrap}>
+      <div className={s.header}>
+        <span className={s.title}>
+          Latency anomalies{' '}
+          {!loading && <span className={s.subtitle}>({items.length} ops)</span>}
+        </span>
+        <span className={s.subtitle}>
+          Operations whose p95 is ≥5× the prior window — click to search
+        </span>
+      </div>
+      {loading ? (
+        <div className={s.skeleton}>
+          {[80, 68, 90, 72, 55].map((w, i) => (
+            <div key={i} className={s.skeletonBar} style={{ width: `${w}%` }} />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className={s.empty}>No anomalies detected in this range.</div>
+      ) : (
+        <ul className={s.list}>
+          {items.map((item) => (
+            <li key={`${item.service}\u0000${item.operation}`}>
+              <Link
+                to={`/search?service=${encodeURIComponent(item.service)}&operation=${encodeURIComponent(item.operation)}&lookback=${lookback}`}
+                className={s.row}
+              >
+                <div className={s.mainCol}>
+                  <div className={s.topLine}>
+                    <span
+                      className={s.svcDot}
+                      style={{ background: serviceColor(item.service) }}
+                    />
+                    <span className={s.svcName}>{item.service}</span>
+                    <span className={s.opName}>{item.operation}</span>
+                  </div>
+                  <div className={s.statLine}>
+                    <span>
+                      <span className={s.statKey}>now p95</span>{' '}
+                      <span className={s.statValue}>
+                        {fmtDurationUs(item.currP95Us)}
+                      </span>
+                    </span>
+                    <span>
+                      <span className={s.statKey}>prev p95</span>{' '}
+                      <span className={s.statValue}>
+                        {fmtDurationUs(item.prevP95Us)}
+                      </span>
+                    </span>
+                    <span>
+                      <span className={s.statKey}>count</span>{' '}
+                      <span className={s.statValue}>
+                        {item.requests.toLocaleString()}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+                <span
+                  className={s.countChip}
+                  style={{
+                    background: 'rgba(6, 182, 212, 0.15)',
+                    color: '#06b6d4',
+                  }}
+                  title={`Current p95 is ${fmtRatio(item.ratio)} the prior-window p95`}
+                >
+                  {fmtRatio(item.ratio)}
+                </span>
+                <span className={s.arrow}>→</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/oteldemo/src/routes/HomePage.module.css
+++ b/oteldemo/src/routes/HomePage.module.css
@@ -263,14 +263,6 @@
   gap: var(--cds-space-lg);
 }
 
-/* Single full-width panel row — used by the latency-anomaly widget,
- * which sits above the two-column slow/error row. */
-.panelsFull {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--cds-space-lg);
-}
-
 @media (max-width: 900px) {
   .panels {
     grid-template-columns: 1fr;

--- a/oteldemo/src/routes/HomePage.module.css
+++ b/oteldemo/src/routes/HomePage.module.css
@@ -263,6 +263,14 @@
   gap: var(--cds-space-lg);
 }
 
+/* Single full-width panel row — used by the latency-anomaly widget,
+ * which sits above the two-column slow/error row. */
+.panelsFull {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--cds-space-lg);
+}
+
 @media (max-width: 900px) {
   .panels {
     grid-template-columns: 1fr;

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -5,11 +5,13 @@ import { binSecondsFor } from '../components/timeRanges';
 import Sparkline from '../components/Sparkline';
 import StatusBanner from '../components/StatusBanner';
 import TraceClassList, { type ClassItem } from '../components/TraceClassList';
+import OperationAnomalyList from '../components/OperationAnomalyList';
 import {
   listServiceSummaries,
   getServiceTimeSeries,
   listSlowTraceClasses,
   listErrorClasses,
+  listOperationAnomalies,
 } from '../api/search';
 import { serviceColor } from '../utils/spans';
 import { serviceHealth, healthRowBg } from '../utils/health';
@@ -22,6 +24,7 @@ import type {
   ServiceBucket,
   SlowTraceClass,
   ErrorClass,
+  OperationAnomaly,
 } from '../api/types';
 import s from './HomePage.module.css';
 
@@ -96,10 +99,12 @@ export default function HomePage() {
   const [buckets, setBuckets] = useState<ServiceBucket[]>([]);
   const [slowClasses, setSlowClasses] = useState<SlowTraceClass[]>([]);
   const [errorClasses, setErrorClasses] = useState<ErrorClass[]>([]);
+  const [anomalies, setAnomalies] = useState<OperationAnomaly[]>([]);
   const [loadingSummaries, setLoadingSummaries] = useState(true);
   const [loadingBuckets, setLoadingBuckets] = useState(true);
   const [loadingSlow, setLoadingSlow] = useState(true);
   const [loadingErrors, setLoadingErrors] = useState(true);
+  const [loadingAnomalies, setLoadingAnomalies] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshMs, setRefreshMs] = useState<number>(DEFAULT_REFRESH_MS);
   const [sort, setSort] = useState<SortState>({ key: 'requests', dir: 'desc' });
@@ -117,6 +122,7 @@ export default function HomePage() {
     setLoadingBuckets(true);
     setLoadingSlow(true);
     setLoadingErrors(true);
+    setLoadingAnomalies(true);
 
     // Fan out — we want the table to populate as soon as summaries arrive,
     // and the sparklines + bottom panels to fill in independently.
@@ -150,7 +156,35 @@ export default function HomePage() {
       .catch(() => setErrorClasses([]))
       .finally(() => setLoadingErrors(false));
 
-    await Promise.allSettled([pSummaries, pPrevSummaries, pBuckets, pSlow, pErrors]);
+    // Latency anomaly detection — runs two KQL queries (current
+    // window + 24h rolling baseline), joins client-side. A long
+    // baseline is necessary: an incident that's been running longer
+    // than the current window would poison a same-length prior
+    // window too, and the anomaly would sit hidden at ratio ≈1×.
+    // 24h covers 23h of healthy history for any incident ≤1h old.
+    //
+    // This is the current approximation — see ROADMAP for the
+    // scheduled-search-backed durable-baseline plan that replaces it.
+    //
+    // Non-fatal on failure; the widget simply shows empty.
+    const pAnomalies = listOperationAnomalies(
+      range,
+      'now',
+      '-25h',
+      range,
+    )
+      .then((r) => setAnomalies(r))
+      .catch(() => setAnomalies([]))
+      .finally(() => setLoadingAnomalies(false));
+
+    await Promise.allSettled([
+      pSummaries,
+      pPrevSummaries,
+      pBuckets,
+      pSlow,
+      pErrors,
+      pAnomalies,
+    ]);
     setLastRefresh(Date.now());
     // streamFilterEnabled is intentionally in the dep list — the
     // queries pick it up from module state at build time, but the
@@ -184,6 +218,15 @@ export default function HomePage() {
     for (const svc of prevSummaries) m.set(svc.service, svc);
     return m;
   }, [prevSummaries]);
+
+  // Services with at least one operation latency anomaly — used by
+  // serviceHealth() to tint the row cyan when a service has any
+  // anomalous op, regardless of where it ranks in the anomaly widget.
+  const anomalousServices = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of anomalies) set.add(a.service);
+    return set;
+  }, [anomalies]);
 
   // Group time-series buckets by service for sparklines
   const sparksByService = useMemo(() => {
@@ -347,12 +390,12 @@ export default function HomePage() {
                 // wrong direction.
                 const prevRaw = prevByService.get(svc.service);
                 const prev = prevRaw && prevRaw.requests >= MIN_PREV_SAMPLES ? prevRaw : undefined;
-                // serviceHealth now takes the previous window so it can
-                // promote to `traffic_drop` when requests fall off
-                // sharply vs baseline — the classic kafka-lag /
-                // starved-consumer signal that error-rate-only
-                // bucketing misses.
-                const health = serviceHealth(svc, prevRaw);
+                // serviceHealth takes the previous window + the
+                // anomalous-services set so it can promote to
+                // `traffic_drop` (rate fell off) or `latency_anomaly`
+                // (specific op is 5×+ slower than baseline) — the
+                // two signals error-rate-only bucketing misses.
+                const health = serviceHealth(svc, prevRaw, anomalousServices);
                 const rowBg = healthRowBg(health.bucket);
                 const prevReqPerMin = prev ? reqPerMin(prev.requests) : undefined;
                 return (
@@ -437,6 +480,18 @@ export default function HomePage() {
             </tbody>
           </table>
         )}
+      </div>
+
+      {/* Anomalies panel — sits above the slow/error row so it reads
+          first. Full-width because anomaly rows carry more text
+          (op name + before/after p95 + count + ratio pill) and would
+          clip in a half-column. */}
+      <div className={s.panelsFull}>
+        <OperationAnomalyList
+          items={anomalies}
+          loading={loadingAnomalies}
+          lookback={range}
+        />
       </div>
 
       {/* Bottom panels: slow trace classes + error classes */}

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -5,13 +5,11 @@ import { binSecondsFor } from '../components/timeRanges';
 import Sparkline from '../components/Sparkline';
 import StatusBanner from '../components/StatusBanner';
 import TraceClassList, { type ClassItem } from '../components/TraceClassList';
-import OperationAnomalyList from '../components/OperationAnomalyList';
 import {
   listServiceSummaries,
   getServiceTimeSeries,
   listSlowTraceClasses,
   listErrorClasses,
-  listOperationAnomalies,
 } from '../api/search';
 import { serviceColor } from '../utils/spans';
 import { serviceHealth, healthRowBg } from '../utils/health';
@@ -24,8 +22,21 @@ import type {
   ServiceBucket,
   SlowTraceClass,
   ErrorClass,
-  OperationAnomaly,
 } from '../api/types';
+
+// NOTE: the latency-anomaly widget + its fetch wiring were removed
+// from this page pending ROADMAP §2b (durable baselines via
+// scheduled Cribl Saved Searches). The in-memory 24h baseline it
+// needed cost ~22s per refresh and couldn't survive incidents
+// older than the baseline window, which made it fire noisily.
+// The building blocks are parked intact and ready to plug back in
+// once the baseline source is durable:
+//   - src/components/OperationAnomalyList.tsx
+//   - src/api/search.ts::listOperationAnomalies
+//   - src/api/queries.ts::allOperationsSummary
+//   - src/api/types.ts::OperationAnomaly
+//   - src/utils/health.ts::latency_anomaly bucket + serviceHealth
+//     `anomalousServices` arg (currently always undefined)
 import s from './HomePage.module.css';
 
 type SortKey =
@@ -99,12 +110,10 @@ export default function HomePage() {
   const [buckets, setBuckets] = useState<ServiceBucket[]>([]);
   const [slowClasses, setSlowClasses] = useState<SlowTraceClass[]>([]);
   const [errorClasses, setErrorClasses] = useState<ErrorClass[]>([]);
-  const [anomalies, setAnomalies] = useState<OperationAnomaly[]>([]);
   const [loadingSummaries, setLoadingSummaries] = useState(true);
   const [loadingBuckets, setLoadingBuckets] = useState(true);
   const [loadingSlow, setLoadingSlow] = useState(true);
   const [loadingErrors, setLoadingErrors] = useState(true);
-  const [loadingAnomalies, setLoadingAnomalies] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshMs, setRefreshMs] = useState<number>(DEFAULT_REFRESH_MS);
   const [sort, setSort] = useState<SortState>({ key: 'requests', dir: 'desc' });
@@ -122,7 +131,6 @@ export default function HomePage() {
     setLoadingBuckets(true);
     setLoadingSlow(true);
     setLoadingErrors(true);
-    setLoadingAnomalies(true);
 
     // Fan out — we want the table to populate as soon as summaries arrive,
     // and the sparklines + bottom panels to fill in independently.
@@ -156,35 +164,7 @@ export default function HomePage() {
       .catch(() => setErrorClasses([]))
       .finally(() => setLoadingErrors(false));
 
-    // Latency anomaly detection — runs two KQL queries (current
-    // window + 24h rolling baseline), joins client-side. A long
-    // baseline is necessary: an incident that's been running longer
-    // than the current window would poison a same-length prior
-    // window too, and the anomaly would sit hidden at ratio ≈1×.
-    // 24h covers 23h of healthy history for any incident ≤1h old.
-    //
-    // This is the current approximation — see ROADMAP for the
-    // scheduled-search-backed durable-baseline plan that replaces it.
-    //
-    // Non-fatal on failure; the widget simply shows empty.
-    const pAnomalies = listOperationAnomalies(
-      range,
-      'now',
-      '-25h',
-      range,
-    )
-      .then((r) => setAnomalies(r))
-      .catch(() => setAnomalies([]))
-      .finally(() => setLoadingAnomalies(false));
-
-    await Promise.allSettled([
-      pSummaries,
-      pPrevSummaries,
-      pBuckets,
-      pSlow,
-      pErrors,
-      pAnomalies,
-    ]);
+    await Promise.allSettled([pSummaries, pPrevSummaries, pBuckets, pSlow, pErrors]);
     setLastRefresh(Date.now());
     // streamFilterEnabled is intentionally in the dep list — the
     // queries pick it up from module state at build time, but the
@@ -218,15 +198,6 @@ export default function HomePage() {
     for (const svc of prevSummaries) m.set(svc.service, svc);
     return m;
   }, [prevSummaries]);
-
-  // Services with at least one operation latency anomaly — used by
-  // serviceHealth() to tint the row cyan when a service has any
-  // anomalous op, regardless of where it ranks in the anomaly widget.
-  const anomalousServices = useMemo(() => {
-    const set = new Set<string>();
-    for (const a of anomalies) set.add(a.service);
-    return set;
-  }, [anomalies]);
 
   // Group time-series buckets by service for sparklines
   const sparksByService = useMemo(() => {
@@ -390,12 +361,14 @@ export default function HomePage() {
                 // wrong direction.
                 const prevRaw = prevByService.get(svc.service);
                 const prev = prevRaw && prevRaw.requests >= MIN_PREV_SAMPLES ? prevRaw : undefined;
-                // serviceHealth takes the previous window + the
-                // anomalous-services set so it can promote to
-                // `traffic_drop` (rate fell off) or `latency_anomaly`
-                // (specific op is 5×+ slower than baseline) — the
-                // two signals error-rate-only bucketing misses.
-                const health = serviceHealth(svc, prevRaw, anomalousServices);
+                // serviceHealth takes the previous window so it can
+                // promote to `traffic_drop` when requests fall off
+                // sharply vs baseline — the classic kafka-lag /
+                // starved-consumer signal that error-rate-only
+                // bucketing misses. The `latency_anomaly` path is
+                // plumbed but disabled until ROADMAP §2b lands a
+                // durable baseline source.
+                const health = serviceHealth(svc, prevRaw);
                 const rowBg = healthRowBg(health.bucket);
                 const prevReqPerMin = prev ? reqPerMin(prev.requests) : undefined;
                 return (
@@ -480,18 +453,6 @@ export default function HomePage() {
             </tbody>
           </table>
         )}
-      </div>
-
-      {/* Anomalies panel — sits above the slow/error row so it reads
-          first. Full-width because anomaly rows carry more text
-          (op name + before/after p95 + count + ratio pill) and would
-          clip in a half-column. */}
-      <div className={s.panelsFull}>
-        <OperationAnomalyList
-          items={anomalies}
-          loading={loadingAnomalies}
-          lookback={range}
-        />
       </div>
 
       {/* Bottom panels: slow trace classes + error classes */}

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -340,8 +340,6 @@ export default function HomePage() {
                 const err = fmtErrorRate(svc.errorRate);
                 const reqSpark = sparksByService.requests.get(svc.service) ?? [];
                 const p95Spark = sparksByService.p95.get(svc.service) ?? [];
-                const health = serviceHealth(svc);
-                const rowBg = healthRowBg(health.bucket);
                 // Only compare against the previous window when it had
                 // enough samples to trust the percentiles. Without this,
                 // services with tiny prev-window volume (flagd, image-
@@ -349,6 +347,13 @@ export default function HomePage() {
                 // wrong direction.
                 const prevRaw = prevByService.get(svc.service);
                 const prev = prevRaw && prevRaw.requests >= MIN_PREV_SAMPLES ? prevRaw : undefined;
+                // serviceHealth now takes the previous window so it can
+                // promote to `traffic_drop` when requests fall off
+                // sharply vs baseline — the classic kafka-lag /
+                // starved-consumer signal that error-rate-only
+                // bucketing misses.
+                const health = serviceHealth(svc, prevRaw);
+                const rowBg = healthRowBg(health.bucket);
                 const prevReqPerMin = prev ? reqPerMin(prev.requests) : undefined;
                 return (
                   <tr

--- a/oteldemo/src/routes/SystemArchPage.tsx
+++ b/oteldemo/src/routes/SystemArchPage.tsx
@@ -11,7 +11,8 @@ import {
   listOperationSummaries,
 } from '../api/search';
 import { binSecondsFor } from '../components/timeRanges';
-import { HEALTH_LEGEND } from '../utils/health';
+import { previousWindow } from '../utils/timeRange';
+import { HEALTH_LEGEND, serviceHealth } from '../utils/health';
 import type {
   DependencyEdge,
   ServiceSummary,
@@ -46,6 +47,7 @@ export default function SystemArchPage() {
   const view: ViewMode = viewParam === 'isometric' ? 'isometric' : 'graph';
   const [edges, setEdges] = useState<DependencyEdge[]>([]);
   const [summaries, setSummaries] = useState<ServiceSummary[]>([]);
+  const [prevSummaries, setPrevSummaries] = useState<ServiceSummary[]>([]);
   const [buckets, setBuckets] = useState<ServiceBucket[]>([]);
   const [loadingDeps, setLoadingDeps] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -91,6 +93,19 @@ export default function SystemArchPage() {
         if (!cancelled) setSummaries([]);
       });
 
+    // Previous-window summaries: feeds the traffic-drop detection
+    // in serviceHealth(). Non-fatal — if this fails we just lose
+    // the drop signal, which is still strictly better than the
+    // pre-existing error-rate-only path.
+    const prev = previousWindow(lookback);
+    listServiceSummaries(prev.earliest, prev.latest)
+      .then((r) => {
+        if (!cancelled) setPrevSummaries(r);
+      })
+      .catch(() => {
+        if (!cancelled) setPrevSummaries([]);
+      });
+
     getServiceTimeSeries(binSeconds, undefined, lookback, 'now')
       .then((r) => {
         if (!cancelled) setBuckets(r);
@@ -130,6 +145,12 @@ export default function SystemArchPage() {
     return m;
   }, [summaries]);
 
+  const prevServicesMap = useMemo(() => {
+    const m = new Map<string, ServiceSummary>();
+    for (const sv of prevSummaries) m.set(sv.service, sv);
+    return m;
+  }, [prevSummaries]);
+
   const bucketsByService = useMemo(() => {
     const m = new Map<string, ServiceBucket[]>();
     for (const b of buckets) {
@@ -148,8 +169,19 @@ export default function SystemArchPage() {
     serviceNames.add(e.child);
   }
 
-  // Count unhealthy services for the toolbar summary
-  const unhealthyCount = summaries.filter((sv) => sv.errorRate > 0).length;
+  // Count unhealthy services for the toolbar summary. Now covers
+  // traffic-drop services too so the count matches what the user
+  // sees visually — a kafka-lag'd service with 0 errors still
+  // counts because its halo will be purple.
+  const unhealthyCount = summaries.filter((sv) => {
+    const h = serviceHealth(sv, prevServicesMap.get(sv.service));
+    return (
+      h.bucket === 'critical' ||
+      h.bucket === 'warn' ||
+      h.bucket === 'watch' ||
+      h.bucket === 'traffic_drop'
+    );
+  }).length;
 
   // Lazy loader passed to each NodeTooltip — fetches per-service
   // operations on hover. Pre-binds the current lookback so the
@@ -204,7 +236,7 @@ export default function SystemArchPage() {
                     />
                   )}
                 </span>
-                {h.bucket}
+                {h.bucket === 'traffic_drop' ? 'traffic drop' : h.bucket}
               </span>
             );
           })}
@@ -222,7 +254,7 @@ export default function SystemArchPage() {
           </span>
           {unhealthyCount > 0 && (
             <span className={s.unhealthy}>
-              {unhealthyCount} with errors
+              {unhealthyCount} needing attention
             </span>
           )}
         </div>
@@ -239,6 +271,7 @@ export default function SystemArchPage() {
           <DependencyGraph
             edges={edges}
             services={servicesMap}
+            prevServices={prevServicesMap}
             bucketsByService={bucketsByService}
             width={dims.w}
             height={dims.h}
@@ -250,6 +283,7 @@ export default function SystemArchPage() {
           <IsometricGraph
             edges={edges}
             services={servicesMap}
+            prevServices={prevServicesMap}
             bucketsByService={bucketsByService}
             width={dims.w}
             height={dims.h}

--- a/oteldemo/src/utils/health.ts
+++ b/oteldemo/src/utils/health.ts
@@ -1,14 +1,35 @@
 /**
  * Map a service's recent stats into a health bucket + display color.
  *
- * Buckets are driven off error rate (primary signal). Latency is shown
- * alongside in the tooltip but doesn't affect the color because an
- * always-slow service isn't necessarily unhealthy — it might just be
- * a compute-heavy workload. Errors are more unambiguously bad.
+ * Two independent signals feed the bucket:
+ *
+ *  - Error rate (primary): countif(status=error) / count(). Error-
+ *    rate bucketing stays as-is — watch / warn / critical thresholds
+ *    at 0 / 1% / 5%. Always-slow is not the same as unhealthy (the
+ *    workload may just be compute-heavy), so latency doesn't drive
+ *    color.
+ *  - Traffic-drop: a significant fall in request rate vs the
+ *    immediately-previous window of the same length. Catches the
+ *    class of outages where a service is quietly starving for work
+ *    (upstream kafka lag, stuck consumer, failed job runner) —
+ *    error rate stays at 0, latency is fine, but requests just
+ *    stop arriving. Error rate alone would keep the service green.
+ *
+ * Bucket precedence: if error rate is already at `warn`/`critical`
+ * severity the error bucket wins (an erroring service is still
+ * erroring regardless of volume). Below that, a significant traffic
+ * drop promotes to `traffic_drop` so the signal doesn't get lost
+ * among the green rows.
  */
 import type { ServiceSummary } from '../api/types';
 
-export type HealthBucket = 'healthy' | 'watch' | 'warn' | 'critical' | 'idle';
+export type HealthBucket =
+  | 'healthy'
+  | 'watch'
+  | 'warn'
+  | 'critical'
+  | 'idle'
+  | 'traffic_drop';
 
 export interface HealthInfo {
   bucket: HealthBucket;
@@ -22,6 +43,10 @@ const HEALTH: Record<HealthBucket, { color: string; label: string }> = {
   warn: { color: '#f59e0b', label: 'Warn (1–5% errors)' },
   critical: { color: '#dc2626', label: 'Critical (>5% errors)' },
   idle: { color: '#9ca3af', label: 'No recent traffic' },
+  traffic_drop: {
+    color: '#a855f7',
+    label: 'Traffic drop vs prior window',
+  },
 };
 
 /** Very subtle row-background tint for a health bucket, matched to
@@ -33,6 +58,7 @@ const HEALTH_BG: Record<HealthBucket, string> = {
   warn: 'rgba(245, 158, 11, 0.12)',
   critical: 'rgba(220, 38, 38, 0.12)',
   idle: 'transparent',
+  traffic_drop: 'rgba(168, 85, 247, 0.12)',
 };
 
 export function healthRowBg(bucket: HealthBucket): string {
@@ -44,14 +70,51 @@ export const HEALTH_LEGEND: Array<{ bucket: HealthBucket; color: string; label: 
   { bucket: 'watch', ...HEALTH.watch },
   { bucket: 'warn', ...HEALTH.warn },
   { bucket: 'critical', ...HEALTH.critical },
+  { bucket: 'traffic_drop', ...HEALTH.traffic_drop },
   { bucket: 'idle', ...HEALTH.idle },
 ];
 
-export function serviceHealth(summary: ServiceSummary | undefined): HealthInfo {
+/**
+ * Minimum prior-window request count for the traffic-drop rule to
+ * fire. Tuned to keep late-night troughs and synthetic traffic gaps
+ * from misfiring — with fewer than this many samples in the prior
+ * window, rate ratios are too noisy to trust.
+ */
+export const MIN_BASELINE_REQUESTS = 50;
+
+/** Traffic-drop triggers when the current window has fallen to
+ * this fraction (or below) of the prior window. 50% is the point
+ * where the drop is meaningful enough to flag but large enough
+ * to avoid false positives during routine minute-to-minute jitter. */
+const TRAFFIC_DROP_THRESHOLD = 0.5;
+
+export function serviceHealth(
+  summary: ServiceSummary | undefined,
+  prev?: ServiceSummary,
+): HealthInfo {
   if (!summary || summary.requests === 0) {
     return { bucket: 'idle', ...HEALTH.idle };
   }
-  return healthFromRate(summary.errorRate);
+  const errInfo = healthFromRate(summary.errorRate);
+  // Errors dominate when they're already significant — an erroring
+  // service is still erroring even if the volume also dropped.
+  if (errInfo.bucket === 'critical' || errInfo.bucket === 'warn') {
+    return errInfo;
+  }
+  // Otherwise check the traffic-drop rule. Requires a prior window
+  // with enough samples to trust the ratio.
+  if (prev && prev.requests >= MIN_BASELINE_REQUESTS) {
+    const ratio = summary.requests / prev.requests;
+    if (ratio <= TRAFFIC_DROP_THRESHOLD) {
+      const dropPct = Math.round((1 - ratio) * 100);
+      return {
+        bucket: 'traffic_drop',
+        color: HEALTH.traffic_drop.color,
+        label: `Traffic down ${dropPct}% vs prior window`,
+      };
+    }
+  }
+  return errInfo;
 }
 
 /** Same bucketing logic, usable for anything with an error rate: edges, operations, ... */

--- a/oteldemo/src/utils/health.ts
+++ b/oteldemo/src/utils/health.ts
@@ -29,7 +29,8 @@ export type HealthBucket =
   | 'warn'
   | 'critical'
   | 'idle'
-  | 'traffic_drop';
+  | 'traffic_drop'
+  | 'latency_anomaly';
 
 export interface HealthInfo {
   bucket: HealthBucket;
@@ -47,6 +48,10 @@ const HEALTH: Record<HealthBucket, { color: string; label: string }> = {
     color: '#a855f7',
     label: 'Traffic drop vs prior window',
   },
+  latency_anomaly: {
+    color: '#06b6d4',
+    label: 'Latency anomaly vs prior window',
+  },
 };
 
 /** Very subtle row-background tint for a health bucket, matched to
@@ -59,6 +64,7 @@ const HEALTH_BG: Record<HealthBucket, string> = {
   critical: 'rgba(220, 38, 38, 0.12)',
   idle: 'transparent',
   traffic_drop: 'rgba(168, 85, 247, 0.12)',
+  latency_anomaly: 'rgba(6, 182, 212, 0.12)',
 };
 
 export function healthRowBg(bucket: HealthBucket): string {
@@ -70,6 +76,7 @@ export const HEALTH_LEGEND: Array<{ bucket: HealthBucket; color: string; label: 
   { bucket: 'watch', ...HEALTH.watch },
   { bucket: 'warn', ...HEALTH.warn },
   { bucket: 'critical', ...HEALTH.critical },
+  { bucket: 'latency_anomaly', ...HEALTH.latency_anomaly },
   { bucket: 'traffic_drop', ...HEALTH.traffic_drop },
   { bucket: 'idle', ...HEALTH.idle },
 ];
@@ -91,18 +98,31 @@ const TRAFFIC_DROP_THRESHOLD = 0.5;
 export function serviceHealth(
   summary: ServiceSummary | undefined,
   prev?: ServiceSummary,
+  /** Set of service names with at least one operation latency
+   * anomaly in the current window. Optional so callers that don't
+   * fetch anomaly data (SystemArchPage, etc.) keep working
+   * unchanged. */
+  anomalousServices?: Set<string>,
 ): HealthInfo {
   if (!summary || summary.requests === 0) {
     return { bucket: 'idle', ...HEALTH.idle };
   }
   const errInfo = healthFromRate(summary.errorRate);
   // Errors dominate when they're already significant — an erroring
-  // service is still erroring even if the volume also dropped.
+  // service is still erroring even if the volume also dropped or a
+  // specific op is anomalously slow.
   if (errInfo.bucket === 'critical' || errInfo.bucket === 'warn') {
     return errInfo;
   }
-  // Otherwise check the traffic-drop rule. Requires a prior window
-  // with enough samples to trust the ratio.
+  // Latency anomaly beats traffic-drop in precedence — a specific
+  // operation that's 5×+ slower than baseline is the more actionable
+  // signal (it points at a named op), while traffic-drop is usually
+  // a symptom of something upstream.
+  if (anomalousServices?.has(summary.service)) {
+    return { bucket: 'latency_anomaly', ...HEALTH.latency_anomaly };
+  }
+  // Traffic-drop rule. Requires a prior window with enough samples
+  // to trust the ratio.
   if (prev && prev.requests >= MIN_BASELINE_REQUESTS) {
     const ratio = summary.requests / prev.requests;
     if (ratio <= TRAFFIC_DROP_THRESHOLD) {

--- a/oteldemo/src/utils/health.ts
+++ b/oteldemo/src/utils/health.ts
@@ -71,12 +71,16 @@ export function healthRowBg(bucket: HealthBucket): string {
   return HEALTH_BG[bucket];
 }
 
+// `latency_anomaly` is intentionally absent from HEALTH_LEGEND right
+// now because nothing in the app actually feeds `anomalousServices`
+// into `serviceHealth()`. See the HomePage.tsx breadcrumb and
+// ROADMAP §2b for why — re-add this line when the durable baseline
+// source lands and the widget gets re-wired.
 export const HEALTH_LEGEND: Array<{ bucket: HealthBucket; color: string; label: string }> = [
   { bucket: 'healthy', ...HEALTH.healthy },
   { bucket: 'watch', ...HEALTH.watch },
   { bucket: 'warn', ...HEALTH.warn },
   { bucket: 'critical', ...HEALTH.critical },
-  { bucket: 'latency_anomaly', ...HEALTH.latency_anomaly },
   { bucket: 'traffic_drop', ...HEALTH.traffic_drop },
   { bucket: 'idle', ...HEALTH.idle },
 ];


### PR DESCRIPTION
**Adds the \`traffic_drop\` health bucket to detect kafka-lag / starved-consumer failure modes where error rate stays at 0% but request rate falls off a cliff. Also introduces the Latency Anomalies widget (v1, parked at end of chunk pending §2b).**

## Commits

- \`4f07a37\` — \`traffic_drop\` health bucket: services whose rate drops ≥50% vs prior window get a cyan row tint + "NN% vs prior" delta chip. Wired into Home + System Architecture.
- \`9b8815b\` — \`OperationAnomalyList\` widget + \`latency_anomaly\` health bucket: per-op p95 vs a 24h in-memory baseline. Works correctly but has two fatal limitations on this deployment's workload.
- \`26e4dad\` — ROADMAP §2 rewritten around scheduled Cribl Saved Searches. Durable baselines, alerts, and SLOs all ride the same provisioning pipeline.
- \`d20f659\` — Park the anomaly widget from Home. Reasons captured in commit body and a breadcrumb comment in \`HomePage.tsx\`: (1) the 24h baseline query was costing ~22 s per Home refresh, dominating the page load; (2) a multi-hour incident poisons a rolling 24h baseline so the detector silently sits at ratio ≈ 1×. Parked until §2b lands a durable baseline source.

## Validate from your phone

Turn on the kafka-lag scenario so the traffic drops kick in:

\`\`\`
scripts/flagd-set.sh kafkaQueueProblems on
\`\`\`

Wait ~5 minutes for traffic to actually drop, then reload Home on your phone:
- https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/

Expected: most service rows tint purple with delta chips showing "-76% vs prior" or similar. \`frontend-proxy\` may stay red (its errors come from a different code path).

Turn it off when you're done:
\`\`\`
scripts/flagd-set.sh kafkaQueueProblems off
\`\`\`

## Context

Historical screenshot (Home with scenario on — taken earlier in today's session):
![traffic-drop during kafka scenario](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/06-traffic-drop-kafka-scenario.png)

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)