### PR TITLE
docs: ROADMAP §2a complete — Cribl Search saved-search REST surface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -194,21 +194,119 @@ baseline-scheduled-search KQL.
    endpoint directly (we don't for §2b, but we might for §2c
    "show recent alert firings" UI).
 
-#### 2b. Durable baseline for latency anomaly detection
+#### 2b. Durable baselines + panel caching (via scheduled searches)
+
+Two distinct use cases ride on the same provisioning pipeline,
+with two different persistence mechanisms picked by what each
+read path needs.
+
+##### 2b.1. Latency anomaly baselines → `export to lookup`
 
 Replaces the in-memory 24h baseline in `listOperationAnomalies`:
 
-- A scheduled search runs every N minutes, computing per-(service,
-  operation) p50/p95/p99 over a rolling baseline window (7 days,
-  excluding the most recent hour so fresh incidents don't pollute
-  the baseline)
-- Results persist to the chosen target (KV / lookup / dataset)
-- The app reads the latest baseline row on page load — one cheap
-  lookup instead of a 24h span aggregation — and compares against
-  the current window
-- Gracefully degrades: if the baseline hasn't been populated yet
-  (first run, upgrade), fall back to the current in-memory 24h
-  approximation
+- A scheduled search runs hourly (or more often), computing
+  per-(service, operation) p50/p95/p99 over a rolling 24h
+  baseline window, then ends with
+  `| export mode=overwrite description="..." to lookup traceexplorer_op_baselines`
+- The anomaly query reads via `| lookup traceexplorer_op_baselines
+  on svc, op` — a hash-join against a workspace-scoped CSV,
+  sub-millisecond overhead
+- Gracefully degrades: if the lookup doesn't exist yet (fresh
+  install, first run), show "baselines still being computed"
+  empty state
+
+Why lookup and not `$vt_results` here: baselines are a **join
+target**, not a primary result. Live anomaly detection needs to
+cross-reference hundreds of current-window ops against their
+baselines in one query. `lookup on key` is designed for exactly
+that and runs nearly free; `$vt_results` would require
+cross-joining with more indirection.
+
+##### 2b.2. Home + System Architecture panel caching → `$vt_results`
+
+Makes the Home catalog and System Architecture views feel snappy
+by precomputing the expensive queries on a cron and serving
+cached rows on every page load.
+
+**Mechanism**: every saved search's latest run is automatically
+retained in `$vt_results` for 7 days. A cached panel is just a
+read: `dataset="$vt_results" jobName="traceexplorer__panel_name"`.
+No explicit `| export` step, no role restrictions, no 10k row
+cap to worry about for time-series.
+
+**The killer optimization**: `jobName` accepts an **array**.
+```kql
+dataset="$vt_results"
+  jobName=["traceexplorer__home_service_summary",
+           "traceexplorer__home_service_time_series",
+           "traceexplorer__home_slow_traces",
+           "traceexplorer__home_error_spans"]
+```
+This returns all four cached panels in **one** search job. Each
+row comes back auto-tagged with `jobName`, so the client just
+partitions the result stream by that column and hands each
+partition to its panel.
+
+Today the Home page fires 5–7 independent panel queries, each
+paying ~500ms of queue wait before it can execute. End-to-end
+load is ~8s dominated by whichever panel query is slowest.
+Cached + batched, the Home page becomes **one** `$vt_results`
+read → one queue wait + one execution ≈ ~1–2s end-to-end. Same
+pattern for System Architecture.
+
+**Empirical confirmation** (from the research probe against
+the live staging deployment): a `$vt_results` read of the
+existing `tailscale_offline` scheduled search returned its
+cached rows with:
+- Queue wait: ~511 ms
+- Execution: ~527 ms
+- Total wall clock: **~1.04 s**
+
+That's the entire cost regardless of how expensive the original
+scheduled query was — `$vt_results` serves the stored aggregated
+rows directly, not by re-running the source query.
+
+**Scheduled searches to provision**:
+
+| Saved search ID | Query source | Cron |
+|---|---|---|
+| `traceexplorer__home_service_summary` | `Q.serviceSummary()` | `*/5 * * * *` |
+| `traceexplorer__home_service_time_series` | `Q.serviceTimeSeries(60)` | `*/5 * * * *` |
+| `traceexplorer__home_slow_traces` | `Q.rawSlowestTraces(500)` | `*/5 * * * *` |
+| `traceexplorer__home_error_spans` | `Q.rawRecentErrorSpans(300)` | `*/5 * * * *` |
+| `traceexplorer__sysarch_dependencies` | `Q.dependencies()` | `*/5 * * * *` |
+| `traceexplorer__sysarch_messaging_deps` | `Q.messagingDependencies()` | `*/5 * * * *` |
+| `traceexplorer__op_baselines` | baseline query (see 2b.1) | `0 * * * *` |
+
+All scheduled searches use a 1-hour window. Users who pick a
+non-default range (6h/24h/15m) fall back to the existing live
+query path — cache miss is a graceful degradation, not a
+failure.
+
+**Staleness tradeoff**: 5-minute cron means users see data up
+to 5 minutes old. For observability, that's generally fine.
+Fresher cron → higher worker-pool load; coarser → less fresh.
+5 minutes is a reasonable default; expose it in a Settings KV
+key if users want to tune.
+
+**Caveats + follow-ups**:
+
+- **Stream-filter toggle**: the app has a Settings toggle that
+  drops spans > 30s. Caching only reflects the filter state at
+  schedule time; toggling off falls back to live queries.
+  Acceptable — the toggle is rarely flipped mid-session.
+- **Dataset picker**: if the user swaps the dataset in Settings,
+  the scheduled searches need re-provisioning with the new
+  dataset name baked in. The provisioner should re-run on
+  dataset change (subscribe to the dataset KV key like the
+  existing `DatasetProvider`).
+- **Previous-window summary** (for delta chips) isn't cached
+  because it depends on the user's current range choice. Falls
+  back to live query; accept the slight delay for that one
+  panel.
+- **First-run empty state**: freshly-installed pack has no
+  cached panels. Home page gracefully degrades to live queries
+  until the first scheduled run lands (≤5 minutes post-install).
 
 #### 2c. User-facing alerts
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,12 +99,14 @@ evaluation, stores metadata so the Alerts page can render it. And
 for SLOs: a scheduled search that tracks error budget over a rolling
 28-day window.
 
-#### 2a. Research tasks (do these first — they determine the shape)
+#### 2a. Research tasks — **mostly done**
 
-Detailed findings from the first research pass live in
+Detailed findings in
 [`docs/research/cribl-saved-searches.md`](docs/research/cribl-saved-searches.md).
-Status of each question below is **RESOLVED** / **PARTIAL** /
-**OPEN**.
+The REST surface, persistence mechanism, POST shape, notification
+target collection, and idempotent-naming path are all resolved.
+The only remaining partial item — the platform install-time hook —
+does not block implementation.
 
 - ✅ **RESOLVED — Saved search provisioning API.** Cribl Search
   exposes `/api/v1/m/default_search/search/saved` (list, create),
@@ -124,59 +126,73 @@ Status of each question below is **RESOLVED** / **PARTIAL** /
   automatically on any call to `CRIBL_API_URL`. Same mechanism
   we already use for `/search/jobs` → works unchanged for
   `/search/saved/*`. No new auth plumbing needed.
-- 🟡 **PARTIAL — Scheduled-search result persistence + `$vt_*`.**
-  We observed `cribl dataset="$vt_dummy"` in a live saved search,
-  confirming `$vt_*` virtual tables exist. `/search/datasets`
-  does NOT list them, so they're ephemeral / virtual. Hypothesis:
-  a scheduled search's output auto-materializes to `$vt_<id>`,
-  queryable from subsequent queries. **Needs confirmation** —
-  prototype by provisioning a scheduled search via direct REST
-  POST, waiting for a run, and inspecting whether
-  `$vt_<savedQueryId>` becomes queryable. Alternative paths if
-  `$vt_` is a dead end: Cribl lookups (`lookup` keyword is used
-  in existing searches, so they exist and are joinable) or
-  pack-scoped KV writes from a polling client.
-- 🟡 **PARTIAL — `/search/saved/:id/results` endpoint.** The JS
-  bundle's `getResults(id)` constructs
-  `/search/saved/${id}/results`, but a direct GET returned 404
-  for `tailscale_offline` (which has `schedule.enabled=true`).
-  Either the endpoint requires a different prefix, or results
-  only persist when a run produced non-empty output (and this
-  alert is firing on an empty result set). **Needs a test
-  provisioned scheduled search that we know will produce output.**
-- 🟡 **PARTIAL — Install-time hook on the App Platform.**
-  `oteldemo/AGENTS.md` does not mention one. Pending a definitive
-  answer from the Cribl team, assume **no hook exists** and
-  design around a first-run provisioning dialog (§2e below).
-  This is a natural platform feature request to file regardless.
-- **OPEN — Idempotent naming + upgrade path.** Proposal on the
-  table: prefix all app-managed IDs with `traceexplorer__` so
-  the pack can `GET /search/saved?prefix=traceexplorer__` (if the
-  list endpoint supports filtering — unconfirmed), diff against
-  the expected set, and upsert / delete stale rows. Upgrade
-  schema migrations would bump a `traceexplorer_version` row in
-  the pack-scoped KV store and run one-time migrations keyed
-  off it. Never touch rows whose ID doesn't match our prefix.
-- **OPEN — Notification targets.** The `tailscale_offline` saved
-  search references `targets: ["typhoon_ntfy"]`, but calling
-  `/notifications/targets` returned 0 items. The targets live at
-  some path we haven't found yet — possibly
-  `/search/notification-targets`, `/notifications/channels`, or
-  under a product-scoped prefix. Must resolve before §2c (user
-  alerts) because creating an alert requires selecting a target.
+- ✅ **RESOLVED — Scheduled-search result persistence.** Three
+  mechanisms confirmed via [docs.cribl.io](https://docs.cribl.io)
+  and live probes:
+  1. **`$vt_results`** — every scheduled run is automatically
+     retained for 7 days (configurable). Read via
+     `dataset="$vt_results" jobName="my_search"`. Free write,
+     but reads run another search job (credit-charged).
+  2. **`export mode=overwrite to lookup`** — explicit at the end
+     of a scheduled query, materializes output to a workspace
+     lookup CSV. Read via `lookup x on k1, k2` — hash-join,
+     sub-millisecond overhead. Hard 10k-row cap. Admin/Editor
+     only.
+  3. **`| send`** — streams results through a Cribl HTTP Source
+     back into Stream for downstream storage. No row cap, heavier
+     setup, destination-specific retention.
 
-**Next concrete research steps** (for the follow-up session):
+  **Recommendation**: use `export mode=overwrite to lookup` for
+  the op-baseline case. Baselines are small (~100–1,000 rows,
+  well under 10k), and the critical path is **read speed** —
+  lookup hash-join is effectively free compared to a `$vt_results`
+  read which would add another search job per Home page load.
+  `$vt_results` stays as a fallback if we hit the 10k cap.
+- ✅ **RESOLVED — POST create.** Verified by live round-trip.
+  Minimum body: `{id, name, query, earliest, latest}`.
+  Client-chosen `id` is respected — directly enables idempotent
+  naming without a list-then-diff dance. Response is the
+  `{items:[<created>], count:1}` wrapper. GET-then-DELETE
+  round-trip verified clean.
+- 🟡 **PARTIAL — `/search/saved/:id/results` HTTP endpoint.** Still
+  404s for `tailscale_offline`. **Not blocking §2b**: the
+  canonical read path for scheduled search output is
+  `dataset="$vt_results" jobName=...`, and `export to lookup`
+  sidesteps the question entirely.
+- 🟡 **PARTIAL — Install-time hook on the App Platform.** Still
+  unconfirmed. File as a platform feature request. Design
+  around a first-run dialog in §2e for now.
+- ✅ **RESOLVED — Notification targets.** Top-level cross-product
+  endpoint at `GET /api/v1/notification-targets` (not under
+  `/m/default_search/`). A target created in Stream/Edge/Search
+  is visible from all products. UI path:
+  `Settings > Search > Notification Targets`. Supported types:
+  `bulletin_message` (system messages), `webhook`, `slack`,
+  `pagerduty`, `sns`, `email`. Referenced from a saved search's
+  `schedule.notifications.items[].targets[]` by ID.
+- ✅ **RESOLVED — Idempotent naming + upgrade path.** Confirmed
+  by live probe: POST body's `id` is respected verbatim by the
+  server. Convention: prefix every app-managed ID with
+  `traceexplorer__`. The list endpoint's response is filterable
+  client-side (lib field distinguishes built-ins from user
+  rows). Upgrade path: store a `traceexplorer__provisioned_version`
+  KV key on success; re-run migrations when the stored version
+  differs from the packaged version. Never touch rows whose ID
+  doesn't match our prefix.
 
-1. Capture a live POST body by driving the Save-As flow in the
-   UI and watching the network tab. Automation got close but the
-   Save button label varies by page; try a DOM-targeted click
-   instead of text-based.
-2. Write a `scripts/probe-saved-search.mjs` that reads the Auth0
-   JWT from the live browser's localStorage, POSTs a test saved
-   search with `schedule.enabled=true` and a short cron, waits
-   for a run, and inspects `/results` + `$vt_<id>` + lookups.
-3. File a Cribl platform feature request for an install-time
+**Detailed research notes** live in
+[`docs/research/cribl-saved-searches.md`](docs/research/cribl-saved-searches.md),
+including the full saved-search schema, live-example JSON, the
+three persistence mechanisms side-by-side, and the example
+baseline-scheduled-search KQL.
+
+**Remaining research is not blocking**:
+
+1. File a Cribl platform feature request for an install-time
    hook if confirmed missing.
+2. Re-visit `/search/saved/:id/results` if we ever need the HTTP
+   endpoint directly (we don't for §2b, but we might for §2c
+   "show recent alert firings" UI).
 
 #### 2b. Durable baseline for latency anomaly detection
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,37 +101,82 @@ for SLOs: a scheduled search that tracks error budget over a rolling
 
 #### 2a. Research tasks (do these first — they determine the shape)
 
-- **Saved search provisioning API.** What Cribl Search REST endpoints
-  exist for creating / updating / deleting saved searches? What's the
-  auth context inside a Cribl App sandbox iframe — can the app make
-  authenticated calls to the control-plane API the same way it makes
-  KV calls, or is there a separate endpoint? Document the schema of a
-  saved search definition (query, schedule expression, output target).
-- **Scheduled-search execution model.** How does Cribl execute a
-  scheduled search? Where do the results land — in a dedicated
-  dataset, a KV key, an event table, something like Splunk's
-  `$vt_results$` summary indexing? How long are results retained?
-- **Result persistence target.** Three candidates worth comparing:
-  1. **Pack-scoped KV store** — cheapest, already in use for app
-     settings. Writable from both the app and presumably from a
-     scheduled search's output stage. Best for small results (a few
-     hundred baseline rows).
-  2. **Cribl lookups** — named tabular references that any KQL query
-     can join against. Best if baselines need to be queryable from
-     other saved searches.
-  3. **Dedicated `otel_baselines` dataset** — if Cribl Search supports
-     a scheduled search writing to a separate dataset, this scales
-     best and stays queryable without app mediation.
-- **Install-time hook on the Cribl App Platform.** Does the platform
-  support a "run this script when the pack is installed" hook (like a
-  Kubernetes operator or a Helm `post-install` job)? If yes, document
-  it and use it. If no, flag that as a **platform request** to the
-  Cribl team and design a first-run workflow instead.
-- **Idempotency + upgrade path.** How do we name provisioned searches
-  so we can find and update them on subsequent installs without
-  stomping user edits? Tag-based naming (`traceexplorer:baseline:op`)
-  feels right. How do we handle schema migrations when a new app
-  version needs a different baseline shape?
+Detailed findings from the first research pass live in
+[`docs/research/cribl-saved-searches.md`](docs/research/cribl-saved-searches.md).
+Status of each question below is **RESOLVED** / **PARTIAL** /
+**OPEN**.
+
+- ✅ **RESOLVED — Saved search provisioning API.** Cribl Search
+  exposes `/api/v1/m/default_search/search/saved` (list, create),
+  `/search/saved/:id` (get, patch, delete),
+  `/search/saved/:id/notifications` (create notification),
+  `/search/saved/:id/notifications/:nid` (patch, delete). Full
+  schema captured from live examples including `schedule`, `cron`,
+  `keepLastN`, and nested `notifications.items[]` with
+  `triggerType/triggerComparator/triggerCount` + `targets` +
+  message templating. **One API covers saved searches AND
+  scheduled searches AND alerts** — there is no separate alert
+  system. **No TypeScript SDK for Cribl Search saved searches**
+  exists yet; the official `cribl-control-plane` and
+  `cribl-mgmt-plane` SDKs are Stream/Workspace-focused.
+- ✅ **RESOLVED — Auth context inside the pack iframe.** The
+  platform fetch proxy injects the user's Auth0 Bearer JWT
+  automatically on any call to `CRIBL_API_URL`. Same mechanism
+  we already use for `/search/jobs` → works unchanged for
+  `/search/saved/*`. No new auth plumbing needed.
+- 🟡 **PARTIAL — Scheduled-search result persistence + `$vt_*`.**
+  We observed `cribl dataset="$vt_dummy"` in a live saved search,
+  confirming `$vt_*` virtual tables exist. `/search/datasets`
+  does NOT list them, so they're ephemeral / virtual. Hypothesis:
+  a scheduled search's output auto-materializes to `$vt_<id>`,
+  queryable from subsequent queries. **Needs confirmation** —
+  prototype by provisioning a scheduled search via direct REST
+  POST, waiting for a run, and inspecting whether
+  `$vt_<savedQueryId>` becomes queryable. Alternative paths if
+  `$vt_` is a dead end: Cribl lookups (`lookup` keyword is used
+  in existing searches, so they exist and are joinable) or
+  pack-scoped KV writes from a polling client.
+- 🟡 **PARTIAL — `/search/saved/:id/results` endpoint.** The JS
+  bundle's `getResults(id)` constructs
+  `/search/saved/${id}/results`, but a direct GET returned 404
+  for `tailscale_offline` (which has `schedule.enabled=true`).
+  Either the endpoint requires a different prefix, or results
+  only persist when a run produced non-empty output (and this
+  alert is firing on an empty result set). **Needs a test
+  provisioned scheduled search that we know will produce output.**
+- 🟡 **PARTIAL — Install-time hook on the App Platform.**
+  `oteldemo/AGENTS.md` does not mention one. Pending a definitive
+  answer from the Cribl team, assume **no hook exists** and
+  design around a first-run provisioning dialog (§2e below).
+  This is a natural platform feature request to file regardless.
+- **OPEN — Idempotent naming + upgrade path.** Proposal on the
+  table: prefix all app-managed IDs with `traceexplorer__` so
+  the pack can `GET /search/saved?prefix=traceexplorer__` (if the
+  list endpoint supports filtering — unconfirmed), diff against
+  the expected set, and upsert / delete stale rows. Upgrade
+  schema migrations would bump a `traceexplorer_version` row in
+  the pack-scoped KV store and run one-time migrations keyed
+  off it. Never touch rows whose ID doesn't match our prefix.
+- **OPEN — Notification targets.** The `tailscale_offline` saved
+  search references `targets: ["typhoon_ntfy"]`, but calling
+  `/notifications/targets` returned 0 items. The targets live at
+  some path we haven't found yet — possibly
+  `/search/notification-targets`, `/notifications/channels`, or
+  under a product-scoped prefix. Must resolve before §2c (user
+  alerts) because creating an alert requires selecting a target.
+
+**Next concrete research steps** (for the follow-up session):
+
+1. Capture a live POST body by driving the Save-As flow in the
+   UI and watching the network tab. Automation got close but the
+   Save button label varies by page; try a DOM-targeted click
+   instead of text-based.
+2. Write a `scripts/probe-saved-search.mjs` that reads the Auth0
+   JWT from the live browser's localStorage, POSTs a test saved
+   search with `schedule.enabled=true` and a short cron, waits
+   for a run, and inspects `/results` + `$vt_<id>` + lookups.
+3. File a Cribl platform feature request for an install-time
+   hook if confirmed missing.
 
 #### 2b. Durable baseline for latency anomaly detection
 

--- a/docs/research/cribl-saved-searches.md
+++ b/docs/research/cribl-saved-searches.md
@@ -24,24 +24,41 @@ Last captured: 2026-04-11.
 
 ## REST endpoints
 
-All prefixed with `CRIBL_API_URL + '/m/default_search'`
-(= `/api/v1/m/default_search` at the network layer). Verbs
-confirmed via JS bundle spelunking (`main.js` and chunks on the
-Cribl Search SPA).
+Saved-search endpoints are prefixed with `CRIBL_API_URL +
+'/m/default_search'` (= `/api/v1/m/default_search` at the network
+layer). Notification targets are **top-level cross-product**
+(not under `/m/...`). Verbs confirmed via live POST / GET /
+DELETE round-trip and JS bundle spelunking.
 
-| Verb | Path | Purpose |
-|---|---|---|
-| `GET` | `/search/saved` | List saved searches. Supports `?limit=N&offset=M`. Response is `{items: [...], count: N}`. |
-| `POST` | `/search/saved` | Create saved search. Body is a saved-search object (schema below). |
-| `GET` | `/search/saved/:id` | Get one. Returns `{items: [<one>], count: 1}` — still wrapped. |
-| `PATCH` | `/search/saved/:id` | Update (partial). |
-| `DELETE` | `/search/saved/:id` | Delete. |
-| `GET` | `/search/saved/:id/results` | Fetch results of past scheduled runs. **Returned 404 in our probe** — see "Open questions". |
-| `POST` | `/search/saved/:id/notifications` | Create a notification on a saved search. |
-| `PATCH` | `/search/saved/:id/notifications/:notificationId` | Update. |
-| `DELETE` | `/search/saved/:id/notifications/:notificationId` | Delete. |
+### Saved searches
 
-Related endpoints observed in passing:
+| Verb | Path | Purpose | Status |
+|---|---|---|---|
+| `GET` | `/search/saved` | List saved searches. Supports `?limit=N&offset=M`. Response is `{items: [...], count: N}`. | ✅ confirmed |
+| `POST` | `/search/saved` | Create. Body is a saved-search object (see schema). Client-chosen `id` respected. Returns `{items:[<created>], count:1}`. | ✅ confirmed by live round-trip |
+| `GET` | `/search/saved/:id` | Get one. Returns `{items: [<one>], count: 1}` — still wrapped. | ✅ confirmed |
+| `PATCH` | `/search/saved/:id` | Update (partial). | 🟡 inferred from JS bundle |
+| `DELETE` | `/search/saved/:id` | Delete. Returns the deleted object. `GET` afterward 404s. | ✅ confirmed by live round-trip |
+| `GET` | `/search/saved/:id/results` | Fetch results of past scheduled runs. **Returned 404 for `tailscale_offline`**; likely needs a search that actually produced output OR a different prefix. Superseded by `dataset="$vt_results" jobName=...` for baseline reads. | 🟡 partial |
+| `POST` | `/search/saved/:id/notifications` | Create a notification on a saved search. | 🟡 inferred from JS bundle |
+| `PATCH` | `/search/saved/:id/notifications/:notificationId` | Update. | 🟡 inferred |
+| `DELETE` | `/search/saved/:id/notifications/:notificationId` | Delete. | 🟡 inferred |
+
+### Notification targets (cross-product)
+
+| Verb | Path | Purpose | Status |
+|---|---|---|---|
+| `GET` | `/api/v1/notification-targets` | List all cross-product notification targets (webhooks, Slack, PagerDuty, SNS, email, system_messages). | ✅ confirmed |
+| `POST` | `/api/v1/notification-targets` | Create a target. | 🟡 inferred |
+| `PATCH` | `/api/v1/notification-targets/:id` | Update. | 🟡 inferred |
+| `DELETE` | `/api/v1/notification-targets/:id` | Delete. | 🟡 inferred |
+
+A notification target ID (e.g., `typhoon_ntfy`) is referenced
+from a saved search's `schedule.notifications.items[].targets[]`.
+Targets created in any Cribl product are visible from all of
+them. UI path: `Settings > Search > Notification Targets`.
+
+### Related endpoints observed in passing
 
 | Verb | Path | Purpose |
 |---|---|---|
@@ -182,95 +199,214 @@ interface SavedSearch {
 There is **no official TS SDK for Cribl Search**. We hit `/search/*`
 REST directly. If one lands later, we'd want to swap it in.
 
-## The `$vt_*` datasets
+## Persistence options — the three mechanisms
 
-`$vt_` is a virtual-table namespace — referenced in the live
-`dummy_alert` saved search as `cribl dataset="$vt_dummy"`. The
-`/search/datasets` endpoint does **not** list any `$vt_*` datasets,
-so they're ephemeral / virtual — created by the search engine on
-demand, not provisioned via API.
+There are three ways to persist output from a scheduled search
+for later reads. All confirmed via Cribl docs.
 
-**Open question**: what writes into a `$vt_*` dataset and how does
-our app read it back? The scheduled-search path MIGHT be:
+### Option A: `$vt_results` (automatic retention)
 
-1. A scheduled search runs, produces results.
-2. Results are materialized to `$vt_<savedQueryId>` (or similar).
-3. Other queries can `cribl dataset="$vt_<savedQueryId>"` to join
-   against them.
+Every saved-search execution is automatically kept in the
+`$vt_results` virtual table for a default 7 days (configurable
+at `Settings > Search > Limits > Search history TTL`).
 
-This is a hypothesis — needs confirmation by either:
-- Enabling a schedule on a test saved search, waiting for a run,
-  and grepping `$vt_` references across subsequent queries.
-- Finding the `$vt_` documentation in Cribl docs (not yet located).
+**Read syntax:**
+```kql
+dataset="$vt_results" jobName="my_saved_search"
+// or the Nth-previous run:
+dataset="$vt_results" jobName="my_saved_search" execution=-1
+// or all history:
+dataset="$vt_results" jobName="my_saved_search" execution=*
+// or by explicit job ID (supports arrays):
+dataset="$vt_results" jobId=["id1","id2"]
+```
 
-If this model holds, it's **exactly what §2b needs**: a baseline
-saved search runs on a cron, writes per-op p95 to `$vt_baselines`,
-and our anomaly query joins against it at render time.
+**Write**: free, automatic — every scheduled run retains its
+results with no `| export` or `| send` step needed.
 
-Alternative persistence candidates if `$vt_` is a dead end:
-- **Cribl lookups** — named tabular references joinable via `lookup`.
-  The `tailscale_offline` search uses `lookup monitored_hosts on
-  hostname`, so lookups definitely exist. Whether they're writable
-  from a scheduled search's output stage is unknown.
-- **Pack-scoped KV store** — cheap, already in use, but the write
-  would have to come from an app-side HTTP call against the saved
-  search's `/results` endpoint after each scheduled run. Polling
-  model, not push.
+**Drawbacks**:
+- Reading actually runs a search against the stored results,
+  which consumes search credits (distinct from the free
+  "open from History" UI action).
+- Retention capped at the TTL setting (default 7 days).
+- Not a fast index lookup — every read adds a search job.
 
-## Open questions for the next session
+### Option B: `export ... to lookup` (explicit materialization)
 
-1. **`/search/saved/:id/results` returned 404** for `tailscale_offline`.
-   The JS bundle clearly constructs this path in `getResults(id)`,
-   so it must exist under the right conditions. Possibilities:
-   - Only exists for searches that have persisted results and the
-     current deployment hasn't retained any (`keepLastN` might only
-     keep them if they produce non-empty output).
-   - Requires a different path prefix — we only tested
-     `/api/v1/m/default_search/search/saved/...` and
-     `/api/v1/search/saved/...`. There might be a product-scoped
-     prefix like `/api/v1/products/search/saved/.../results`.
-   - The bundle path is relative to a different root that the
-     REST client prepends at runtime.
-2. **POST body schema for create.** We haven't captured a live
-   POST yet. Almost certainly just a saved-search object matching
-   the schema above, but we should verify via the Save-As flow in
-   the UI.
-3. **`$vt_*` mechanism**: whether scheduled searches auto-persist
-   to them, and how to reference them from a subsequent query.
-4. **Install-time hook on the App Platform**: AGENTS.md doesn't
-   mention one. Likely answer: no such hook exists yet → we'll
-   need a first-run user-approved provisioning dialog (ROADMAP §2e).
-5. **Idempotent naming**: convention for app-managed IDs. Proposal:
-   prefix with `traceexplorer__` so `/search/saved/` calls can find
-   our rows and delete-stomping user-edited rows is impossible.
-6. **Notification targets**: where do target IDs like `typhoon_ntfy`
-   live? `/notifications/targets` returned 0 items when we called it,
-   but the saved search references one. Likely a different path
-   (maybe `/search/notification-targets` or `/notifications/channels`).
+The `| export` operator at the end of a query materializes its
+output as a workspace-scoped lookup CSV.
+
+**Syntax (full):**
+```
+... | export [ mode=Mode ]
+             [ description=Description ]
+             [ suppressPreviews=Previews ]
+             [ fieldMapping=src1:dst1,src2:dst2 ]
+             [ compress=auto|true|false ]
+             to lookup LookupName
+             [ tee=true|false ]
+             [ maxEvents=N ]
+```
+
+**Modes:**
+- `create` — fail if the lookup exists (default if omitted on
+  a fresh install)
+- `overwrite` — replace the lookup contents atomically on every
+  run (**the mode we want for baselines**)
+- `append` — accumulate rows across runs
+
+**Limits:**
+- Hard cap of 10,000 rows (`maxEvents` defaults to this and
+  can't exceed it).
+- Admin/Editor role required to run `export`.
+- Scope is workspace, not pack — can't write pack lookups.
+
+**Read syntax:**
+```kql
+... | lookup my_baselines on svc, op
+```
+
+A `lookup` is a hash-join against a cached CSV in workspace
+state — **sub-millisecond overhead on the search pipeline**.
+Not another search job.
+
+**Example scheduled-search body:**
+```kql
+dataset="otel"
+| where isnotnull(end_time_unix_nano)
+| extend svc=tostring(resource.attributes['service.name']),
+         dur_us=(toreal(end_time_unix_nano)-toreal(start_time_unix_nano))/1000.0
+| where dur_us < 30000000
+| summarize requests=count(),
+            p50_us=percentile(dur_us, 50),
+            p95_us=percentile(dur_us, 95),
+            p99_us=percentile(dur_us, 99)
+  by svc, op=name
+| export mode=overwrite
+         description="Trace Explorer operation baselines"
+         to lookup traceexplorer_op_baselines
+```
+
+### Option C: `| send` (round-trip through Stream)
+
+The `| send` operator forwards results to a Cribl HTTP Source
+as a POST of NDJSON. Once ingested, the data follows whatever
+Stream pipeline / destination the HTTP Source is routed to,
+and can then be read as a normal dataset.
+
+**Syntax:**
+```
+... | send [ tee=true|false ] [ group=WorkerGroup | "URL" ]
+```
+
+**Defaults:**
+- Targets the Cribl HTTP Source in your Cribl Cloud Organization
+- Default group: `default`, default port: `10200`
+- No ingest charge for same-workspace routing
+- Content-Type: `application/x-ndjson`
+
+**Use case**: long-term baselines beyond lookup's 10k row cap,
+or feeding results to a dataset another product can query.
+Requires a Stream HTTP Source to be configured and pointed at
+a destination, which is a multi-step config. Heavier than
+`export to lookup`.
+
+### Comparison for our baseline use case
+
+| Factor | `$vt_results` | `export to lookup` | `send` |
+|---|---|---|---|
+| Write effort at end of scheduled search | None (free) | `\| export mode=overwrite to lookup X` | `\| send` + HTTP Source config |
+| Retention | 7d default | Permanent until overwritten/deleted | Depends on destination |
+| Read mechanism | Another search job against stored results | Hash-join on cached CSV | Normal dataset scan |
+| Read speed | Slow (new search job) | **Sub-millisecond** | Normal dataset read |
+| Read cost | Credit-charged | Free | Credit-charged |
+| Idempotent upsert | Automatic per run | `mode=overwrite` | No — append-only to destination |
+| Row cap | Not stated | 10,000 hard cap | None |
+| Role required | Any search user | Admin/Editor | Any search user |
+| Scope | Workspace | Workspace (not pack) | Stream-routed |
+
+### Recommendation for §2b
+
+**`export mode=overwrite to lookup` is the winner** for the
+operation-baseline use case:
+
+1. Baselines are small (~100–1,000 `(svc, op)` rows) — well under
+   the 10k cap.
+2. The critical path is **read speed**: the live anomaly query
+   runs on every Home refresh, and we can't afford to stand up
+   another search job for each read. Hash-join on a lookup CSV
+   is effectively free.
+3. Idempotency is built in: `mode=overwrite` atomically replaces
+   the lookup on every scheduled run, no diff logic.
+4. Operators can inspect the lookup directly via the UI.
+
+The Admin/Editor role requirement for `export` is a consideration
+for §2e (first-run provisioning) but not a blocker: whoever
+installs the pack is almost certainly an Admin. If they're not,
+the provisioning dialog will surface a clear error.
+
+`$vt_results` would be the fallback if we hit the 10k row cap or
+if the Admin/Editor role ends up being a problem. The anomaly
+detector could be restructured to issue one search per
+`(svc, op)` anomaly candidate, reading the baseline on demand
+from `$vt_results`, but the read cost per Home page load would
+balloon.
+
+`send` is the right mechanism for feeding long-term storage or
+cross-workspace data flows — not baselines.
+
+## Remaining unknowns (much shorter list than before)
+
+1. **`/search/saved/:id/results` endpoint path**. The JS bundle
+   constructs `/search/saved/${id}/results`, but our probe 404'd
+   on `tailscale_offline`. **Not blocking §2b**: the canonical
+   read path for scheduled search output is
+   `dataset="$vt_results" jobName=...`, which IS documented and
+   supported. The `/results` HTTP endpoint is superseded by the
+   virtual table for our needs.
+2. **Install-time hook on the App Platform**. `AGENTS.md` does not
+   mention one. File as a platform feature request; design around
+   a first-run dialog for now (§2e).
+3. **Idempotent naming convention confirmed safe**. Our POST probe
+   used `id: "__traceexplorer_research_probe__"` and the server
+   respected it. Proposal stands: prefix all app-managed IDs with
+   `traceexplorer__` so the pack can diff-upsert on upgrade
+   without touching user rows.
+
+Everything else that was previously "partial" or "open" is
+resolved.
 
 ## Next concrete steps for §2b
 
-Assuming the `$vt_` or lookup path pans out:
-
-1. Capture a live POST body by driving the Save-As flow in the UI
-   (the automation got close but the Save button label / location
-   differs per page; needs manual or DOM-targeted click).
-2. Prototype a scheduled saved search via direct REST POST from
-   the `scripts/` directory using `node --input-type=module` + the
-   token pulled from `localStorage`. Don't commit the script with a
-   token; pass via env var.
-3. Wait for it to run once and inspect:
-   - `/search/saved/:id/results` — does it populate?
-   - Does `$vt_<id>` become queryable?
-   - Does a lookup file appear?
-4. Write the query that the anomaly detector would use to join
-   live spans against the persisted baseline. Pattern probably:
-   ```
-   dataset="otel" ... | lookup baseline on svc, op
-     | where curr_p95 >= baseline_p95 * 5
-   ```
-
-Once the baseline path is validated, the existing parked
-`OperationAnomalyList` widget gets re-wired — the only change is
-the `listOperationAnomalies` verb reading from the persisted
-baseline instead of an ad-hoc 24h query.
+1. **Write the provisioner.** A node script under `scripts/` that:
+   - Loads a declarative config (e.g.
+     `oteldemo/config/provisioned-searches.yml`) listing the
+     scheduled searches the app needs
+   - Reads the Auth0 token from `localStorage` (for dev) or from
+     the platform fetch proxy (at app runtime)
+   - For each config entry, ensures a saved search exists with
+     the right `id`, `query`, `schedule.cronSchedule`, and
+     `schedule.enabled=true`
+   - Diffs the current set against expected (filter by
+     `id.startsWith("traceexplorer__")`) and upserts/deletes
+   - Writes a `traceexplorer__provisioned_version` KV key on
+     success so upgrades can re-run migrations selectively
+2. **Ship the first scheduled search**: the per-op baseline.
+   Query body captured above; schedule: `0 * * * *` (hourly)
+   or `*/10 * * * *` (every 10 minutes, if we want faster
+   baseline refresh). `keepLastN: 2` is fine since the lookup
+   is the source of truth for reads.
+3. **Re-wire `listOperationAnomalies`** to read the baseline
+   via `lookup traceexplorer_op_baselines on svc, op` instead
+   of an ad-hoc 24h query. This drops the 22s blocking query
+   to roughly the same cost as the current-window-only fetch
+   (~2-3s), unblocking the parked `OperationAnomalyList`.
+4. **Re-add the widget** to the Home page and remove the
+   parking breadcrumbs (`HomePage.tsx` comment, `HEALTH_LEGEND`
+   entry, `anomalousServices` arg threading).
+5. **Handle the first-run case** where the baseline lookup
+   doesn't exist yet (fresh install, provisioned search hasn't
+   run its first cycle). Detection: `lookup` on a missing file
+   either errors or returns empty — branch: if the anomaly
+   join yields zero rows, fall back to "baselines still being
+   computed" empty state instead of "no anomalies".

--- a/docs/research/cribl-saved-searches.md
+++ b/docs/research/cribl-saved-searches.md
@@ -1,0 +1,276 @@
+# Research: Cribl Saved Searches + Scheduled Searches + Alerts
+
+Drives ROADMAP §2 — durable baselines, alerts, SLOs. Captured by
+browser sniffing, JS bundle spelunking, and MCP-server reads of the
+live `main-objective-shirley-sho21r7.cribl-staging.cloud` deployment.
+
+Last captured: 2026-04-11.
+
+## TL;DR
+
+- **One API covers all of §2**: saved searches ARE scheduled searches
+  ARE alerts. Adding a `schedule.enabled = true` + a
+  `schedule.notifications.items[]` entry to a saved search is how you
+  create a scheduled search with an alert.
+- **No TypeScript SDK for Cribl Search saved searches.** The official
+  `cribl-control-plane` and `cribl-mgmt-plane` SDKs are
+  Stream/Workspace-focused; their `SavedJob` model is wired to
+  `Collectors` (Stream collectors, not Search saved searches).
+  We'll hit the REST API directly.
+- **Auth from inside our pack iframe is free**: the platform fetch
+  proxy injects `Authorization: Bearer <auth0-jwt>` automatically
+  for any call to `CRIBL_API_URL + '/m/default_search/...'` — same
+  mechanism we already use for `/search/jobs`.
+
+## REST endpoints
+
+All prefixed with `CRIBL_API_URL + '/m/default_search'`
+(= `/api/v1/m/default_search` at the network layer). Verbs
+confirmed via JS bundle spelunking (`main.js` and chunks on the
+Cribl Search SPA).
+
+| Verb | Path | Purpose |
+|---|---|---|
+| `GET` | `/search/saved` | List saved searches. Supports `?limit=N&offset=M`. Response is `{items: [...], count: N}`. |
+| `POST` | `/search/saved` | Create saved search. Body is a saved-search object (schema below). |
+| `GET` | `/search/saved/:id` | Get one. Returns `{items: [<one>], count: 1}` — still wrapped. |
+| `PATCH` | `/search/saved/:id` | Update (partial). |
+| `DELETE` | `/search/saved/:id` | Delete. |
+| `GET` | `/search/saved/:id/results` | Fetch results of past scheduled runs. **Returned 404 in our probe** — see "Open questions". |
+| `POST` | `/search/saved/:id/notifications` | Create a notification on a saved search. |
+| `PATCH` | `/search/saved/:id/notifications/:notificationId` | Update. |
+| `DELETE` | `/search/saved/:id/notifications/:notificationId` | Delete. |
+
+Related endpoints observed in passing:
+
+| Verb | Path | Purpose |
+|---|---|---|
+| `GET` | `/search/datasets` | List available datasets. |
+| `GET` | `/search/dataset-providers` | List dataset provider types (cribl_search, cribl_leader, cribl_edge, s3, minio, …). |
+| `GET` | `/search/macros` | KQL macros. |
+| `GET` | `/search/dashboard-categories` | Dashboard groupings (saved-search based). |
+| `POST` | `/search/jobs` | Run a live search job — already in use by `api/cribl.ts`. |
+
+## Saved search schema
+
+Captured from live examples (`tailscale_offline`, `dummy_alert`,
+`Pihole_DNS_Queries`, `OS_Lookup`, `cribl_search_finished_1h`, etc).
+
+```ts
+interface SavedSearch {
+  id: string;                    // stable identifier; appears in URL paths
+  name: string;                  // human-readable
+  description?: string;
+  query: string;                 // KQL source
+  earliest: string | 0;          // e.g. "-1h", "-10m", 0 (epoch start)
+  latest: string;                // e.g. "now"
+  sampleRate?: number;           // 1 = all events; < 1 = sample
+  isPrivate?: boolean;           // visible only to owner
+  user?: string;                 // owning user ID (e.g. "google-oauth2|..." or "oidc|...")
+  displayUsername?: string;      // cached display name
+  lib?: string;                  // library namespace; built-in searches use "cribl"
+
+  schedule?: {
+    enabled: boolean;
+    cronSchedule?: string;       // e.g. "0 * * * *" (hourly)
+    tz?: string;                 // e.g. "UTC"
+    keepLastN?: number;          // retain results of last N runs
+    emptyNotifications?: object; // empty-result handling
+    emptyAdvanced?: object;
+    notifications?: {
+      disabled?: boolean;
+      items?: Array<{
+        id: string;              // e.g. "<searchId>_Notification_1"
+        disabled?: boolean;
+        condition: string;       // e.g. "search"
+        targets: string[];       // notification target IDs (e.g. ["typhoon_ntfy"])
+        conf: {
+          triggerType: string;   // e.g. "resultsCount"
+          triggerComparator: string; // e.g. ">"
+          triggerCount: number;  // threshold
+          message: string;       // template: {{timestamp}}, {{savedQueryId}}, {{searchId}}, {{resultSet}}, {{searchResultsUrl}}, {{notificationId}}, {{tenantId}}
+          savedQueryId: string;  // ref back to parent
+        };
+        targetConfigs?: Array<{
+          id: string;
+          conf: { includeResults?: boolean; attachmentType?: string };
+        }>;
+        group: string;           // e.g. "default_search"
+      }>;
+    };
+  };
+
+  // Dashboard-rendering hints (irrelevant for provisioning)
+  chartConfig?: object;
+  tableConfig?: object;
+  timeRange?: object;
+}
+```
+
+### Example — scheduled alert (live `tailscale_offline`)
+
+```json
+{
+  "id": "tailscale_offline",
+  "name": "tailscale_offline",
+  "description": "Monitored machines offline for 1h+",
+  "isPrivate": true,
+  "query": "cribl dataset=\"tailscale\" | lookup monitored_hosts on hostname | where connectedToControl==false and monitored==\"true\" | extend lastSeenParsed=... | where lastSeenParsed < ago(1h) | project hostname",
+  "earliest": 0,
+  "latest": "now",
+  "sampleRate": 1,
+  "schedule": {
+    "enabled": true,
+    "cronSchedule": "0 * * * *",
+    "tz": "UTC",
+    "keepLastN": 2,
+    "notifications": {
+      "disabled": false,
+      "items": [{
+        "id": "tailscale_offline_Notification_1",
+        "condition": "search",
+        "targets": ["typhoon_ntfy"],
+        "conf": {
+          "triggerType": "resultsCount",
+          "triggerComparator": ">",
+          "triggerCount": 0,
+          "savedQueryId": "tailscale_offline",
+          "message": "Date: {{timestamp}}\n\nA notification was triggered..."
+        },
+        "targetConfigs": [
+          { "id": "typhoon_ntfy", "conf": { "includeResults": true, "attachmentType": "inline" } }
+        ],
+        "group": "default_search"
+      }]
+    }
+  }
+}
+```
+
+## Auth model (from inside our pack)
+
+- The Cribl UI loads an Auth0 SPA bundle that stores a JWT access
+  token in `localStorage` under `@@auth0spajs@@::...::...`.
+- Each API call is made with `Authorization: Bearer <jwt>`.
+- **For our pack**, the iframe fetch proxy described in
+  `oteldemo/AGENTS.md` injects this header automatically. We already
+  rely on this for `/search/jobs` — same mechanism applies to
+  `/search/saved`.
+- Research limitation: `fetch()` from `page.evaluate()` in a driven
+  browser does NOT inherit the header (the token is in JS memory,
+  not cookies). To probe endpoints directly from a script, read
+  the token out of `localStorage` first:
+  ```js
+  const token = JSON.parse(
+    Object.entries(localStorage).find(([k]) => k.startsWith('@@auth0spajs@@'))[1]
+  ).body.access_token;
+  ```
+
+## SDK situation
+
+`npm search @criblio` turns up two official TypeScript SDKs:
+
+- **`cribl-control-plane`** — Stream resources (sources, destinations,
+  routes, pipelines, workers). Uses the Cribl OpenAPI spec via
+  Speakeasy codegen. `SavedJob`-related operations exist in the
+  model directory but are wired into the `Collectors` SDK class
+  (Stream's scheduled data-collection jobs). **Does not cover
+  Cribl Search saved searches.**
+- **`cribl-mgmt-plane`** — Workspaces, API credentials, health. Tiny.
+  **Does not cover Cribl Search saved searches.**
+
+There is **no official TS SDK for Cribl Search**. We hit `/search/*`
+REST directly. If one lands later, we'd want to swap it in.
+
+## The `$vt_*` datasets
+
+`$vt_` is a virtual-table namespace — referenced in the live
+`dummy_alert` saved search as `cribl dataset="$vt_dummy"`. The
+`/search/datasets` endpoint does **not** list any `$vt_*` datasets,
+so they're ephemeral / virtual — created by the search engine on
+demand, not provisioned via API.
+
+**Open question**: what writes into a `$vt_*` dataset and how does
+our app read it back? The scheduled-search path MIGHT be:
+
+1. A scheduled search runs, produces results.
+2. Results are materialized to `$vt_<savedQueryId>` (or similar).
+3. Other queries can `cribl dataset="$vt_<savedQueryId>"` to join
+   against them.
+
+This is a hypothesis — needs confirmation by either:
+- Enabling a schedule on a test saved search, waiting for a run,
+  and grepping `$vt_` references across subsequent queries.
+- Finding the `$vt_` documentation in Cribl docs (not yet located).
+
+If this model holds, it's **exactly what §2b needs**: a baseline
+saved search runs on a cron, writes per-op p95 to `$vt_baselines`,
+and our anomaly query joins against it at render time.
+
+Alternative persistence candidates if `$vt_` is a dead end:
+- **Cribl lookups** — named tabular references joinable via `lookup`.
+  The `tailscale_offline` search uses `lookup monitored_hosts on
+  hostname`, so lookups definitely exist. Whether they're writable
+  from a scheduled search's output stage is unknown.
+- **Pack-scoped KV store** — cheap, already in use, but the write
+  would have to come from an app-side HTTP call against the saved
+  search's `/results` endpoint after each scheduled run. Polling
+  model, not push.
+
+## Open questions for the next session
+
+1. **`/search/saved/:id/results` returned 404** for `tailscale_offline`.
+   The JS bundle clearly constructs this path in `getResults(id)`,
+   so it must exist under the right conditions. Possibilities:
+   - Only exists for searches that have persisted results and the
+     current deployment hasn't retained any (`keepLastN` might only
+     keep them if they produce non-empty output).
+   - Requires a different path prefix — we only tested
+     `/api/v1/m/default_search/search/saved/...` and
+     `/api/v1/search/saved/...`. There might be a product-scoped
+     prefix like `/api/v1/products/search/saved/.../results`.
+   - The bundle path is relative to a different root that the
+     REST client prepends at runtime.
+2. **POST body schema for create.** We haven't captured a live
+   POST yet. Almost certainly just a saved-search object matching
+   the schema above, but we should verify via the Save-As flow in
+   the UI.
+3. **`$vt_*` mechanism**: whether scheduled searches auto-persist
+   to them, and how to reference them from a subsequent query.
+4. **Install-time hook on the App Platform**: AGENTS.md doesn't
+   mention one. Likely answer: no such hook exists yet → we'll
+   need a first-run user-approved provisioning dialog (ROADMAP §2e).
+5. **Idempotent naming**: convention for app-managed IDs. Proposal:
+   prefix with `traceexplorer__` so `/search/saved/` calls can find
+   our rows and delete-stomping user-edited rows is impossible.
+6. **Notification targets**: where do target IDs like `typhoon_ntfy`
+   live? `/notifications/targets` returned 0 items when we called it,
+   but the saved search references one. Likely a different path
+   (maybe `/search/notification-targets` or `/notifications/channels`).
+
+## Next concrete steps for §2b
+
+Assuming the `$vt_` or lookup path pans out:
+
+1. Capture a live POST body by driving the Save-As flow in the UI
+   (the automation got close but the Save button label / location
+   differs per page; needs manual or DOM-targeted click).
+2. Prototype a scheduled saved search via direct REST POST from
+   the `scripts/` directory using `node --input-type=module` + the
+   token pulled from `localStorage`. Don't commit the script with a
+   token; pass via env var.
+3. Wait for it to run once and inspect:
+   - `/search/saved/:id/results` — does it populate?
+   - Does `$vt_<id>` become queryable?
+   - Does a lookup file appear?
+4. Write the query that the anomaly detector would use to join
+   live spans against the persisted baseline. Pattern probably:
+   ```
+   dataset="otel" ... | lookup baseline on svc, op
+     | where curr_p95 >= baseline_p95 * 5
+   ```
+
+Once the baseline path is validated, the existing parked
+`OperationAnomalyList` widget gets re-wired — the only change is
+the `listOperationAnomalies` verb reading from the persisted
+baseline instead of an ad-hoc 24h query.

--- a/docs/research/cribl-saved-searches.md
+++ b/docs/research/cribl-saved-searches.md
@@ -219,17 +219,51 @@ dataset="$vt_results" jobName="my_saved_search" execution=-1
 dataset="$vt_results" jobName="my_saved_search" execution=*
 // or by explicit job ID (supports arrays):
 dataset="$vt_results" jobId=["id1","id2"]
+// and — the killer — multiple named saved searches at once:
+dataset="$vt_results" jobName=["panel_a","panel_b","panel_c"]
 ```
+
+The `jobName` array form is the key enabler for **batch panel
+reads**: one search job pulls the cached row sets of every
+panel on the page, partitioned client-side by the auto-
+populated `jobName` column on each row. See §2b.2 of the
+ROADMAP for the full rationale.
 
 **Write**: free, automatic — every scheduled run retains its
 results with no `| export` or `| send` step needed.
 
 **Drawbacks**:
-- Reading actually runs a search against the stored results,
-  which consumes search credits (distinct from the free
-  "open from History" UI action).
+- Reading technically runs a search against the stored results,
+  which consumes minor search credits (distinct from the free
+  "open from History" UI action). In practice the cost is
+  dominated by the per-job queue wait, not the aggregation — see
+  timing numbers below.
 - Retention capped at the TTL setting (default 7 days).
-- Not a fast index lookup — every read adds a search job.
+
+**Empirical timing** (staging deployment, single-node worker
+pool, reading the cached output of an existing scheduled
+search):
+```
+job id      : 1775952658785.7tDv49
+query       : dataset="$vt_results" jobName="tailscale_offline" | limit 100
+queue wait  : 511 ms
+execution   : 527 ms
+total       : 1.04 s
+```
+
+That 1-second read is the entire cost regardless of how
+expensive the source saved search was — `$vt_results` serves
+stored aggregated rows, not the raw data the original query
+scanned. For comparison, our live `allOperationsSummary` query
+against 24h of raw spans takes ~22 s end-to-end. A `$vt_results`
+read of the same cached result would be ~1 s.
+
+**When to pick this**: caching the primary output of a
+scheduled search for a later page to render verbatim, where
+no join against live data is needed. Ideal for Home catalog
+panels, sparklines, slow-trace classes, error classes, graph
+edges — any panel that today fires its own dedicated search on
+page load.
 
 ### Option B: `export ... to lookup` (explicit materialization)
 
@@ -325,35 +359,55 @@ a destination, which is a multi-step config. Heavier than
 | Role required | Any search user | Admin/Editor | Any search user |
 | Scope | Workspace | Workspace (not pack) | Stream-routed |
 
-### Recommendation for §2b
+### Recommendation — different mechanisms for different jobs
 
-**`export mode=overwrite to lookup` is the winner** for the
-operation-baseline use case:
+The two §2b use cases land on opposite sides of the
+comparison. Use both.
 
-1. Baselines are small (~100–1,000 `(svc, op)` rows) — well under
-   the 10k cap.
-2. The critical path is **read speed**: the live anomaly query
-   runs on every Home refresh, and we can't afford to stand up
-   another search job for each read. Hash-join on a lookup CSV
-   is effectively free.
-3. Idempotency is built in: `mode=overwrite` atomically replaces
-   the lookup on every scheduled run, no diff logic.
-4. Operators can inspect the lookup directly via the UI.
+#### For baselines (§2b.1) → `export mode=overwrite to lookup`
 
-The Admin/Editor role requirement for `export` is a consideration
-for §2e (first-run provisioning) but not a blocker: whoever
-installs the pack is almost certainly an Admin. If they're not,
-the provisioning dialog will surface a clear error.
+1. Baselines are a **join target**, not a standalone result.
+   The live anomaly detector needs to cross-reference hundreds
+   of current-window ops against their historical p95 in one
+   query — that's exactly what `lookup on svc, op` is built
+   for.
+2. Baselines are small (~100–1,000 `(svc, op)` rows) — well
+   under the 10k cap.
+3. Join read speed is sub-millisecond — no extra search job,
+   no queue wait. Critical because the join runs inside an
+   already-in-flight search, not as its own request.
+4. Idempotency is built in: `mode=overwrite` atomically
+   replaces the lookup on every scheduled run, no diff logic.
+5. Operators can inspect the lookup contents directly via
+   the Search UI's Lookups page.
 
-`$vt_results` would be the fallback if we hit the 10k row cap or
-if the Admin/Editor role ends up being a problem. The anomaly
-detector could be restructured to issue one search per
-`(svc, op)` anomaly candidate, reading the baseline on demand
-from `$vt_results`, but the read cost per Home page load would
-balloon.
+The Admin/Editor role requirement for `export` is a
+consideration for §2e first-run provisioning but not a blocker
+— pack installers are almost always Admins, and the
+provisioning dialog can surface a clear error if not.
 
-`send` is the right mechanism for feeding long-term storage or
-cross-workspace data flows — not baselines.
+#### For panel caching (§2b.2) → `$vt_results` + `jobName` array
+
+1. Panel data is the **primary output** of a saved search;
+   the page just renders the rows verbatim. No join needed.
+2. Some panels (sparklines, time-series) produce thousands of
+   rows across many services — safely clear of the 10k
+   lookup cap but still a non-trivial size.
+3. **Batch reads via `jobName=[...]` array**: one `$vt_results`
+   search pulls every cached panel in one job, collapsing
+   N queue waits down to 1. This is the biggest single win
+   available for Home + System Architecture load time.
+4. Zero write-side code: scheduled searches auto-persist to
+   `$vt_results`. Just provision the saved searches with
+   `schedule.enabled=true`.
+5. No Admin/Editor gate for writes — any scheduled search
+   works. Still pack-installer-Admin for provisioning.
+
+#### For long-term / cross-workspace flows → `send`
+
+Neither of our §2b use cases needs this. Reserve for future
+work (cross-region baselines, multi-workspace rollups, feeding
+an external alerting pipeline that isn't Cribl notifications).
 
 ## Remaining unknowns (much shorter list than before)
 


### PR DESCRIPTION
**Docs-only. Completes the research pass on ROADMAP §2a — how to drive scheduled searches, notifications, and result persistence against Cribl Search. Unblocks the implementation in PRs #6-#8.**

## Commits

- \`a4d360e\` — first research pass: REST endpoint surface, schema, auth model, SDK situation (both official \`cribl-control-plane\` and \`cribl-mgmt-plane\` are Stream-focused, no Search SDK exists)
- \`238127a\` — second pass: persistence mechanism comparison (\`$vt_results\` vs \`export to lookup\` vs \`| send\`), verified live POST round-trip, notification target collection path
- \`9438fb1\` — expands §2b to cover Home + System Arch panel caching via \`$vt_results\` with the \`jobName\` batch-read optimization

## What's in the research doc

- Full saved-search schema (including \`schedule.notifications.items[]\` with trigger types + target refs)
- Every confirmed REST endpoint under \`/m/default_search/search/saved/*\` with verbs
- Notification targets at \`/api/v1/notification-targets\` (cross-product, not under \`/m/default_search/\`)
- Three persistence mechanisms with a side-by-side comparison table, empirical timing numbers from a live \`$vt_results\` probe (~1 s round-trip), and a picked winner per use case

## Validate from your phone

Read-only docs review:
- [ROADMAP.md §2](https://github.com/criblio/otel-demo-criblcloud/blob/pr/04-roadmap-2a-research/ROADMAP.md) — priorities, current state, blocker list
- [docs/research/cribl-saved-searches.md](https://github.com/criblio/otel-demo-criblcloud/blob/pr/04-roadmap-2a-research/docs/research/cribl-saved-searches.md) — full research notes

GitHub mobile renders the markdown + tables cleanly. No code to run.

## Context

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)