### PR TITLE
rename: Trace Explorer → Cribl APM

### DIFF
--- a/FAILURE-SCENARIOS.md
+++ b/FAILURE-SCENARIOS.md
@@ -3,14 +3,14 @@
 The upstream OpenTelemetry Demo ships a [flagd](https://flagd.dev/) service
 with 15 failure-injection flags. This document covers how to turn each one
 on against the kind cluster on `clintdev`, what telemetry signals to
-expect, and which view in the Trace Explorer app is supposed to surface
+expect, and which view in the Cribl APM app is supposed to surface
 it. Use this as a regression test plan when iterating on the app.
 
 ## Prerequisites
 
 - `ssh clintdev` works
 - kind cluster `otel-demo-cribl` is running in Docker on that host
-- Trace Explorer app is deployed to the Cribl Cloud staging environment
+- Cribl APM app is deployed to the Cribl Cloud staging environment
   and the OTel telemetry pipeline is shipping data to the `otel` dataset
 
 ## Helper script

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# Trace Explorer — Roadmap
+# Cribl APM — Roadmap
 
 This document is the canonical priority list for the `oteldemo/` Cribl
 Search App. It captures the competitive gap analysis we ran against
@@ -14,7 +14,7 @@ alerts, query language, federation) rather than reinvent them.
 
 ## Guiding principle: lean on Cribl Search
 
-The Trace Explorer runs *inside* Cribl Search. Cribl Search already
+The Cribl APM runs *inside* Cribl Search. Cribl Search already
 provides:
 
 - **Saved searches** — named, shareable KQL queries with persistence
@@ -39,7 +39,7 @@ Concretely, that shapes every roadmap item:
   ServiceDetail, and arch graph that builds a saved-search + alert
   definition under the hood, then calls the Cribl API to persist it
 - "Saved views" → Cribl saved searches owned by the app, tagged with
-  a `traceexplorer:view` tag so we can list and render them
+  a `criblapm:view` tag so we can list and render them
 - "Dashboards" → a set of saved searches composed into a page; still
   backed by Cribl, rendered by us
 - "Query language" → we keep the guided forms as the primary surface
@@ -173,9 +173,9 @@ does not block implementation.
 - ✅ **RESOLVED — Idempotent naming + upgrade path.** Confirmed
   by live probe: POST body's `id` is respected verbatim by the
   server. Convention: prefix every app-managed ID with
-  `traceexplorer__`. The list endpoint's response is filterable
+  `criblapm__`. The list endpoint's response is filterable
   client-side (lib field distinguishes built-ins from user
-  rows). Upgrade path: store a `traceexplorer__provisioned_version`
+  rows). Upgrade path: store a `criblapm__provisioned_version`
   KV key on success; re-run migrations when the stored version
   differs from the packaged version. Never touch rows whose ID
   doesn't match our prefix.
@@ -207,8 +207,8 @@ Replaces the in-memory 24h baseline in `listOperationAnomalies`:
 - A scheduled search runs hourly (or more often), computing
   per-(service, operation) p50/p95/p99 over a rolling 24h
   baseline window, then ends with
-  `| export mode=overwrite description="..." to lookup traceexplorer_op_baselines`
-- The anomaly query reads via `| lookup traceexplorer_op_baselines
+  `| export mode=overwrite description="..." to lookup criblapm_op_baselines`
+- The anomaly query reads via `| lookup criblapm_op_baselines
   on svc, op` — a hash-join against a workspace-scoped CSV,
   sub-millisecond overhead
 - Gracefully degrades: if the lookup doesn't exist yet (fresh
@@ -230,17 +230,17 @@ cached rows on every page load.
 
 **Mechanism**: every saved search's latest run is automatically
 retained in `$vt_results` for 7 days. A cached panel is just a
-read: `dataset="$vt_results" jobName="traceexplorer__panel_name"`.
+read: `dataset="$vt_results" jobName="criblapm__panel_name"`.
 No explicit `| export` step, no role restrictions, no 10k row
 cap to worry about for time-series.
 
 **The killer optimization**: `jobName` accepts an **array**.
 ```kql
 dataset="$vt_results"
-  jobName=["traceexplorer__home_service_summary",
-           "traceexplorer__home_service_time_series",
-           "traceexplorer__home_slow_traces",
-           "traceexplorer__home_error_spans"]
+  jobName=["criblapm__home_service_summary",
+           "criblapm__home_service_time_series",
+           "criblapm__home_slow_traces",
+           "criblapm__home_error_spans"]
 ```
 This returns all four cached panels in **one** search job. Each
 row comes back auto-tagged with `jobName`, so the client just
@@ -270,13 +270,13 @@ rows directly, not by re-running the source query.
 
 | Saved search ID | Query source | Cron |
 |---|---|---|
-| `traceexplorer__home_service_summary` | `Q.serviceSummary()` | `*/5 * * * *` |
-| `traceexplorer__home_service_time_series` | `Q.serviceTimeSeries(60)` | `*/5 * * * *` |
-| `traceexplorer__home_slow_traces` | `Q.rawSlowestTraces(500)` | `*/5 * * * *` |
-| `traceexplorer__home_error_spans` | `Q.rawRecentErrorSpans(300)` | `*/5 * * * *` |
-| `traceexplorer__sysarch_dependencies` | `Q.dependencies()` | `*/5 * * * *` |
-| `traceexplorer__sysarch_messaging_deps` | `Q.messagingDependencies()` | `*/5 * * * *` |
-| `traceexplorer__op_baselines` | baseline query (see 2b.1) | `0 * * * *` |
+| `criblapm__home_service_summary` | `Q.serviceSummary()` | `*/5 * * * *` |
+| `criblapm__home_service_time_series` | `Q.serviceTimeSeries(60)` | `*/5 * * * *` |
+| `criblapm__home_slow_traces` | `Q.rawSlowestTraces(500)` | `*/5 * * * *` |
+| `criblapm__home_error_spans` | `Q.rawRecentErrorSpans(300)` | `*/5 * * * *` |
+| `criblapm__sysarch_dependencies` | `Q.dependencies()` | `*/5 * * * *` |
+| `criblapm__sysarch_messaging_deps` | `Q.messagingDependencies()` | `*/5 * * * *` |
+| `criblapm__op_baselines` | baseline query (see 2b.1) | `0 * * * *` |
 
 All scheduled searches use a 1-hour window. Users who pick a
 non-default range (6h/24h/15m) fall back to the existing live
@@ -334,7 +334,7 @@ semantics and UI (error budget remaining, burn alerts at 1h / 6h /
 Assuming no install hook exists:
 
 - On first load, the app checks KV for a `provisioned-version` key
-- If absent or stale, show a one-time dialog: "Trace Explorer needs
+- If absent or stale, show a one-time dialog: "Cribl APM needs
   to create N scheduled searches to power baselines and alerts.
   [Create them]"
 - App calls the saved-search API with idempotent names; if a search

--- a/docs/research/cribl-saved-searches.md
+++ b/docs/research/cribl-saved-searches.md
@@ -317,8 +317,8 @@ dataset="otel"
             p99_us=percentile(dur_us, 99)
   by svc, op=name
 | export mode=overwrite
-         description="Trace Explorer operation baselines"
-         to lookup traceexplorer_op_baselines
+         description="Cribl APM operation baselines"
+         to lookup criblapm_op_baselines
 ```
 
 ### Option C: `| send` (round-trip through Stream)
@@ -422,9 +422,9 @@ an external alerting pipeline that isn't Cribl notifications).
    mention one. File as a platform feature request; design around
    a first-run dialog for now (§2e).
 3. **Idempotent naming convention confirmed safe**. Our POST probe
-   used `id: "__traceexplorer_research_probe__"` and the server
+   used `id: "__criblapm_research_probe__"` and the server
    respected it. Proposal stands: prefix all app-managed IDs with
-   `traceexplorer__` so the pack can diff-upsert on upgrade
+   `criblapm__` so the pack can diff-upsert on upgrade
    without touching user rows.
 
 Everything else that was previously "partial" or "open" is
@@ -442,8 +442,8 @@ resolved.
      the right `id`, `query`, `schedule.cronSchedule`, and
      `schedule.enabled=true`
    - Diffs the current set against expected (filter by
-     `id.startsWith("traceexplorer__")`) and upserts/deletes
-   - Writes a `traceexplorer__provisioned_version` KV key on
+     `id.startsWith("criblapm__")`) and upserts/deletes
+   - Writes a `criblapm__provisioned_version` KV key on
      success so upgrades can re-run migrations selectively
 2. **Ship the first scheduled search**: the per-op baseline.
    Query body captured above; schedule: `0 * * * *` (hourly)
@@ -451,7 +451,7 @@ resolved.
    baseline refresh). `keepLastN: 2` is fine since the lookup
    is the source of truth for reads.
 3. **Re-wire `listOperationAnomalies`** to read the baseline
-   via `lookup traceexplorer_op_baselines on svc, op` instead
+   via `lookup criblapm_op_baselines on svc, op` instead
    of an ad-hoc 24h query. This drops the 22s blocking query
    to roughly the same cost as the current-window-only fetch
    (~2-3s), unblocking the parked `OperationAnomalyList`.

--- a/oteldemo/README.md
+++ b/oteldemo/README.md
@@ -1,4 +1,4 @@
-# Trace Explorer — Cribl Search App
+# Cribl APM — Cribl Search App
 
 A Jaeger UI clone built as a [Cribl App Platform](AGENTS.md) app. Visualizes
 distributed traces from the OpenTelemetry demo against the `otel` lakehouse

--- a/oteldemo/package.json
+++ b/oteldemo/package.json
@@ -44,8 +44,8 @@
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4"
   },
-  "displayName": "OpenTelemetry Demo",
-  "description": "Visualize data from the OpenTelemetry demo",
+  "displayName": "Cribl APM",
+  "description": "Application performance monitoring on top of Cribl Search — traces, logs, and metrics from the OpenTelemetry demo.",
   "author": "Clint Sharp",
   "navItems": [
     {

--- a/oteldemo/src/components/NavBar.tsx
+++ b/oteldemo/src/components/NavBar.tsx
@@ -29,7 +29,7 @@ export default function NavBar() {
           <circle cx="11" cy="11" r="7" />
           <path d="M21 21l-4.35-4.35" />
         </svg>
-        Trace Explorer
+        Cribl APM
       </NavLink>
 
       <div className={s.tabs}>

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -262,7 +262,7 @@ export default function HomePage() {
       {/* Hero bar with title, range picker, auto-refresh toggle */}
       <div className={s.hero}>
         <div>
-          <h1 className={s.heroTitle}>Trace Explorer</h1>
+          <h1 className={s.heroTitle}>Cribl APM</h1>
           <div className={s.heroSubtitle}>
             Service catalog, recent activity, and live trace data from the{' '}
             <code>otel</code> dataset.

--- a/oteldemo/src/routes/SettingsPage.tsx
+++ b/oteldemo/src/routes/SettingsPage.tsx
@@ -106,7 +106,7 @@ export default function SettingsPage() {
       <div className={s.card}>
         <h2 className={s.sectionTitle}>Dataset</h2>
         <p className={s.sectionHelp}>
-          All Trace Explorer queries run against this Cribl Search dataset.
+          All Cribl APM queries run against this Cribl Search dataset.
           It should contain OpenTelemetry span + log events (i.e. the same
           schema produced by the OpenTelemetry Collector's OTLP pipeline).
           Defaults to <code>otel</code>.


### PR DESCRIPTION
**Product rename. User-facing strings, identifiers, and docs all flip in one atomic commit.**

## Commits

- \`c4ebd99\` — find-and-replace with two case-preserving substitutions:
  - \`Trace Explorer\` → \`Cribl APM\` (user-facing)
  - \`traceexplorer\` → \`criblapm\` (identifiers: future saved-search IDs, lookup names, KV keys, tag prefixes)

## What's in it

- Home hero title, NavBar brand link, Settings help text
- `oteldemo/README.md`, `ROADMAP.md`, `FAILURE-SCENARIOS.md`
- `docs/research/cribl-saved-searches.md` example baseline description
- `oteldemo/package.json` \`displayName\` (was "OpenTelemetry Demo", now "Cribl APM" per follow-up request) — this is what shows in the Cribl App Platform catalog
- All planned saved-search IDs in ROADMAP + research notes flipped to the \`criblapm__\` prefix

## Deliberately left alone

- `oteldemo/package.json` \`"name": "oteldemo"\` — internal pack ID, changing it requires repointing the deploy script and the `/apps/oteldemo/` install path on the cluster. Separate task.

## Validate from your phone

Open https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/ and verify:
- Navbar brand reads **Cribl APM**
- Home hero title reads **Cribl APM**
- Settings → Dataset section help text says "All Cribl APM queries run against..."
- Cribl App Platform app list (from the main Cribl UI's Apps menu) shows **Cribl APM** instead of "OpenTelemetry Demo"

## Context

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)