### PR TITLE
oteldemo: scheduled-search provisioner + Settings UI panel

### DIFF
--- a/oteldemo/src/api/provisionedSearches.ts
+++ b/oteldemo/src/api/provisionedSearches.ts
@@ -1,0 +1,220 @@
+/**
+ * Declarative inventory of every scheduled Cribl Saved Search that
+ * Cribl APM provisions and relies on at runtime. Two categories:
+ *
+ *  1. **Panel caches** — precomputed query outputs for the Home and
+ *     System Architecture panels. Read back via $vt_results by
+ *     jobName (§2b.2 in the ROADMAP). One batched $vt_results
+ *     query pulls every cached panel in a single search job
+ *     because jobName accepts an array.
+ *
+ *  2. **Op-baseline lookup** — rolling 24h per-(service, operation)
+ *     p95 snapshot, written to a workspace lookup via
+ *     `export mode=overwrite`. Joined against live queries by the
+ *     latency anomaly detector (§2b.1).
+ *
+ * The provisioner at api/provisioner.ts reads this list, compares
+ * it to the server's current set of criblapm__* saved searches,
+ * and upserts / deletes as needed. See ROADMAP §2b for the full
+ * rationale.
+ *
+ * IDs are prefixed with `criblapm__` (double underscore) so a
+ * prefix match is enough to find app-managed rows without risk of
+ * touching user-created searches.
+ *
+ * The query bodies are produced by calling the standard builders
+ * in queries.ts. Those functions read the current dataset and
+ * stream-filter state at invocation time, so if those settings
+ * change the provisioner must be re-run to pick up the new
+ * baked-in values. The ROADMAP caveats section covers this.
+ */
+import * as Q from './queries';
+
+/** Stable prefix for every app-managed saved search ID. Used by
+ * the provisioner to find and reconcile rows without stomping
+ * user-created searches. */
+export const CRIBLAPM_PREFIX = 'criblapm__';
+
+/** Name of the workspace lookup the op-baseline search writes to.
+ * The live anomaly detector joins against this via
+ * `| lookup criblapm_op_baselines on svc, op`. Single underscore
+ * intentionally — lookup names can't start with the double-
+ * underscore pattern without looking weird in the UI. */
+export const OP_BASELINES_LOOKUP = 'criblapm_op_baselines';
+
+/** The subset of the Cribl saved-search object that the provisioner
+ * cares about. The server fills in the rest (`user`, etc.). */
+export interface ProvisionedSearch {
+  id: string;
+  name: string;
+  description: string;
+  query: string;
+  earliest: string;
+  latest: string;
+  sampleRate?: number;
+  schedule: {
+    enabled: boolean;
+    cronSchedule: string;
+    tz: string;
+    keepLastN: number;
+  };
+}
+
+/**
+ * Baseline query for the latency anomaly detector. Same aggregation
+ * as `Q.allOperationsSummary` (with the span-level stream filter
+ * applied so idle-poll noise doesn't poison the baseline), but
+ * terminates with `| export mode=overwrite to lookup` so each
+ * scheduled run atomically replaces the workspace lookup.
+ *
+ * Scope: 24h window (configured at the scheduled search level via
+ * `earliest: "-24h"`). 10,000 row cap is ample — our demo has ~100
+ * distinct (svc, op) pairs, production workloads typically stay
+ * under 2,000.
+ *
+ * The query builder here is NOT exported from queries.ts because
+ * it's coupled to the export-to-lookup behavior and isn't used
+ * live. Keep it local.
+ */
+function opBaselineQuery(): string {
+  const base = Q.allOperationsSummary(10_000);
+  return `${base}
+    | export mode=overwrite
+             description="Cribl APM — rolling 24h per-op p95 baseline"
+             to lookup ${OP_BASELINES_LOOKUP}`;
+}
+
+/**
+ * Declarative list of every scheduled search the app needs. Order
+ * doesn't matter functionally but matches the ROADMAP §2b.2 table
+ * for easy cross-referencing.
+ *
+ * All panel caches run every five minutes (cron: "star-slash-5
+ * star star star star") over a rolling 1-hour window. That matches
+ * the default range users see on the Home and System Architecture
+ * pages. Users who pick a non-default range (6h / 24h / 15m) fall
+ * back to the live query path — graceful cache miss, not a failure.
+ *
+ * The op-baseline runs hourly ("0 * * * *") over a 24-hour window.
+ * Baselines move slowly; running more often is wasted worker time.
+ */
+export function getProvisioningPlan(): ProvisionedSearch[] {
+  const everyFiveMin = {
+    enabled: true,
+    cronSchedule: '*/5 * * * *',
+    tz: 'UTC',
+    keepLastN: 2,
+  } as const;
+  const hourly = {
+    enabled: true,
+    cronSchedule: '0 * * * *',
+    tz: 'UTC',
+    keepLastN: 2,
+  } as const;
+
+  return [
+    // ── Home panel caches ───────────────────────────────────
+    {
+      id: 'criblapm__home_service_summary',
+      name: 'Cribl APM — home service summary',
+      description:
+        'Cribl APM: per-service rate / errors / p50 / p95 / p99 for the Home catalog. Read via $vt_results.',
+      query: Q.serviceSummary(),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    {
+      id: 'criblapm__home_service_time_series',
+      name: 'Cribl APM — home service time series',
+      description:
+        'Cribl APM: per-service request/error/p95 buckets for Home sparklines (60s bins). Read via $vt_results.',
+      query: Q.serviceTimeSeries(60),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    {
+      id: 'criblapm__home_slow_traces',
+      name: 'Cribl APM — home slow trace classes',
+      description:
+        'Cribl APM: raw slow-trace rows (root svc/op + trace duration) for the Slowest Trace Classes panel. Read via $vt_results.',
+      query: Q.rawSlowestTraces(500),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    {
+      id: 'criblapm__home_error_spans',
+      name: 'Cribl APM — home error spans',
+      description:
+        'Cribl APM: recent error spans for the Home Error Classes panel. Read via $vt_results.',
+      query: Q.rawRecentErrorSpans(300),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    // ── System Architecture panel caches ────────────────────
+    {
+      id: 'criblapm__sysarch_dependencies',
+      name: 'Cribl APM — system architecture RPC dependencies',
+      description:
+        'Cribl APM: service→service RPC edges via parent_span_id self-join. Read via $vt_results.',
+      query: Q.dependencies(),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    {
+      id: 'criblapm__sysarch_messaging_deps',
+      name: 'Cribl APM — system architecture messaging dependencies',
+      description:
+        'Cribl APM: kafka / messaging edges aggregated by (service, topic, operation). Read via $vt_results.',
+      query: Q.messagingDependencies(),
+      earliest: '-1h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...everyFiveMin },
+    },
+    // ── Op baseline lookup ──────────────────────────────────
+    {
+      id: 'criblapm__op_baselines',
+      name: 'Cribl APM — per-op 24h latency baselines',
+      description:
+        'Cribl APM: rolling 24h per-(service, operation) p50/p95/p99 baseline, materialized as the criblapm_op_baselines lookup for the anomaly detector.',
+      query: opBaselineQuery(),
+      earliest: '-24h',
+      latest: 'now',
+      sampleRate: 1,
+      schedule: { ...hourly },
+    },
+  ];
+}
+
+/** Convenience: return just the IDs, in the order the plan
+ * declares them. Used by the batched $vt_results panel-read
+ * verb so the client sends them all in one jobName array. */
+export function getHomePanelJobNames(): string[] {
+  return [
+    'criblapm__home_service_summary',
+    'criblapm__home_service_time_series',
+    'criblapm__home_slow_traces',
+    'criblapm__home_error_spans',
+  ];
+}
+
+/** Companion for the System Architecture page. */
+export function getSystemArchPanelJobNames(): string[] {
+  return [
+    'criblapm__sysarch_dependencies',
+    'criblapm__sysarch_messaging_deps',
+    // Home-shared panels reused on the arch page
+    'criblapm__home_service_summary',
+    'criblapm__home_service_time_series',
+  ];
+}

--- a/oteldemo/src/api/provisionedSearches.ts
+++ b/oteldemo/src/api/provisionedSearches.ts
@@ -80,7 +80,7 @@ function opBaselineQuery(): string {
   const base = Q.allOperationsSummary(10_000);
   return `${base}
     | export mode=overwrite
-             description="Cribl APM — rolling 24h per-op p95 baseline"
+             description="Cribl APM - rolling 24h per-op p95 baseline"
              to lookup ${OP_BASELINES_LOOKUP}`;
 }
 
@@ -116,7 +116,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     // ── Home panel caches ───────────────────────────────────
     {
       id: 'criblapm__home_service_summary',
-      name: 'Cribl APM — home service summary',
+      name: 'Cribl APM - home service summary',
       description:
         'Cribl APM: per-service rate / errors / p50 / p95 / p99 for the Home catalog. Read via $vt_results.',
       query: Q.serviceSummary(),
@@ -127,7 +127,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     },
     {
       id: 'criblapm__home_service_time_series',
-      name: 'Cribl APM — home service time series',
+      name: 'Cribl APM - home service time series',
       description:
         'Cribl APM: per-service request/error/p95 buckets for Home sparklines (60s bins). Read via $vt_results.',
       query: Q.serviceTimeSeries(60),
@@ -138,7 +138,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     },
     {
       id: 'criblapm__home_slow_traces',
-      name: 'Cribl APM — home slow trace classes',
+      name: 'Cribl APM - home slow trace classes',
       description:
         'Cribl APM: raw slow-trace rows (root svc/op + trace duration) for the Slowest Trace Classes panel. Read via $vt_results.',
       query: Q.rawSlowestTraces(500),
@@ -149,7 +149,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     },
     {
       id: 'criblapm__home_error_spans',
-      name: 'Cribl APM — home error spans',
+      name: 'Cribl APM - home error spans',
       description:
         'Cribl APM: recent error spans for the Home Error Classes panel. Read via $vt_results.',
       query: Q.rawRecentErrorSpans(300),
@@ -161,7 +161,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     // ── System Architecture panel caches ────────────────────
     {
       id: 'criblapm__sysarch_dependencies',
-      name: 'Cribl APM — system architecture RPC dependencies',
+      name: 'Cribl APM - system architecture RPC dependencies',
       description:
         'Cribl APM: service→service RPC edges via parent_span_id self-join. Read via $vt_results.',
       query: Q.dependencies(),
@@ -172,7 +172,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     },
     {
       id: 'criblapm__sysarch_messaging_deps',
-      name: 'Cribl APM — system architecture messaging dependencies',
+      name: 'Cribl APM - system architecture messaging dependencies',
       description:
         'Cribl APM: kafka / messaging edges aggregated by (service, topic, operation). Read via $vt_results.',
       query: Q.messagingDependencies(),
@@ -184,7 +184,7 @@ export function getProvisioningPlan(): ProvisionedSearch[] {
     // ── Op baseline lookup ──────────────────────────────────
     {
       id: 'criblapm__op_baselines',
-      name: 'Cribl APM — per-op 24h latency baselines',
+      name: 'Cribl APM - per-op 24h latency baselines',
       description:
         'Cribl APM: rolling 24h per-(service, operation) p50/p95/p99 baseline, materialized as the criblapm_op_baselines lookup for the anomaly detector.',
       query: opBaselineQuery(),

--- a/oteldemo/src/api/provisioner.ts
+++ b/oteldemo/src/api/provisioner.ts
@@ -1,0 +1,340 @@
+/**
+ * Scheduled-search provisioner.
+ *
+ * Reconciles the workspace's set of `criblapm__*` saved searches
+ * with the declarative plan in `provisionedSearches.ts`. Used by:
+ *
+ *  - scripts/provision-searches.mjs at dev time (manual runs by
+ *    humans against a staging deployment)
+ *  - the in-app first-run / Settings "Re-provision" flow at
+ *    runtime (planned — §2e in the ROADMAP)
+ *
+ * Safety model: we only ever look at rows whose `id` starts with
+ * the `criblapm__` prefix. Everything else is invisible to this
+ * module. A reconciliation run can create, update, or delete
+ * prefixed rows; it will never touch a row a user created by
+ * hand.
+ *
+ * The Cribl Search saved-search REST surface this module uses:
+ *
+ *   GET    /m/default_search/search/saved          (list)
+ *   POST   /m/default_search/search/saved          (create)
+ *   GET    /m/default_search/search/saved/:id      (get)
+ *   PATCH  /m/default_search/search/saved/:id      (update)
+ *   DELETE /m/default_search/search/saved/:id      (delete)
+ *
+ * All confirmed via the research pass in
+ * `docs/research/cribl-saved-searches.md`. Auth comes from the
+ * platform fetch proxy at app runtime, or from an explicit
+ * Bearer token when invoked from the node-side script.
+ */
+import {
+  getProvisioningPlan,
+  CRIBLAPM_PREFIX,
+  type ProvisionedSearch,
+} from './provisionedSearches';
+
+/** Minimal shape of a saved-search row as returned by the list
+ * endpoint. We don't need the full schema here — just enough
+ * to identify app-managed rows and diff against the plan. */
+export interface SavedSearchRow {
+  id: string;
+  name?: string;
+  description?: string;
+  query?: string;
+  earliest?: string | number;
+  latest?: string | number;
+  sampleRate?: number;
+  schedule?: unknown;
+}
+
+interface SavedSearchListResponse {
+  items?: SavedSearchRow[];
+  count?: number;
+}
+
+/** Plan entry classified by what the reconciler needs to do. */
+export type PlanAction =
+  | { kind: 'create'; want: ProvisionedSearch }
+  | { kind: 'update'; want: ProvisionedSearch; current: SavedSearchRow }
+  | { kind: 'delete'; current: SavedSearchRow }
+  | { kind: 'noop'; want: ProvisionedSearch; current: SavedSearchRow };
+
+/** Abstract HTTP client so the same module can run inside the
+ * browser (via `fetch`) and from a node-side driver (via a
+ * fetch shim that injects a Bearer token). Both paths must
+ * target the same endpoints and return parsed JSON. */
+export interface HttpClient {
+  get(path: string): Promise<unknown>;
+  post(path: string, body: unknown): Promise<unknown>;
+  patch(path: string, body: unknown): Promise<unknown>;
+  del(path: string): Promise<unknown>;
+}
+
+/** Path builder — every saved-search URL is under this prefix. */
+export function savedSearchesPath(id?: string): string {
+  const base = '/m/default_search/search/saved';
+  return id ? `${base}/${encodeURIComponent(id)}` : base;
+}
+
+/** Fetch every `criblapm__*` saved search currently on the
+ * server. Pagination is not strictly necessary at our scale
+ * (we have <10 managed rows) but we include it for safety
+ * against a very large workspace. */
+export async function listProvisioned(
+  http: HttpClient,
+): Promise<SavedSearchRow[]> {
+  const out: SavedSearchRow[] = [];
+  const pageSize = 200;
+  let offset = 0;
+  // Hard cap on loop iterations so a buggy server can't spin
+  // us forever — 10k rows is already far beyond sensible.
+  for (let page = 0; page < 50; page++) {
+    const resp = (await http.get(
+      `${savedSearchesPath()}?limit=${pageSize}&offset=${offset}`,
+    )) as SavedSearchListResponse;
+    const items = resp?.items ?? [];
+    for (const row of items) {
+      if (typeof row?.id === 'string' && row.id.startsWith(CRIBLAPM_PREFIX)) {
+        out.push(row);
+      }
+    }
+    if (items.length < pageSize) break;
+    offset += items.length;
+  }
+  return out;
+}
+
+/** Compare the expected plan against the current server state
+ * and classify every row into one of four actions. Comparison
+ * semantics:
+ *
+ *   - A row in the plan with no server counterpart → create.
+ *   - A row on the server whose `id` doesn't appear in the plan
+ *     → delete (stale / removed from a previous pack version).
+ *   - A row in both → check whether the interesting fields
+ *     (query, earliest, latest, schedule, description, name)
+ *     match. If any differ → update. If all match → noop.
+ *
+ * The noop branch lets the provisioner be idempotent: running
+ * it repeatedly when nothing has changed produces zero writes.
+ */
+export function diffProvisioned(
+  plan: ProvisionedSearch[],
+  current: SavedSearchRow[],
+): PlanAction[] {
+  const byId = new Map<string, SavedSearchRow>();
+  for (const row of current) byId.set(row.id, row);
+
+  const actions: PlanAction[] = [];
+  const planIds = new Set<string>();
+
+  for (const want of plan) {
+    planIds.add(want.id);
+    const cur = byId.get(want.id);
+    if (!cur) {
+      actions.push({ kind: 'create', want });
+      continue;
+    }
+    if (isSameAsPlan(want, cur)) {
+      actions.push({ kind: 'noop', want, current: cur });
+    } else {
+      actions.push({ kind: 'update', want, current: cur });
+    }
+  }
+
+  for (const row of current) {
+    if (!planIds.has(row.id)) {
+      actions.push({ kind: 'delete', current: row });
+    }
+  }
+
+  return actions;
+}
+
+/** Strict-ish equality check between a planned row and the
+ * server's current copy. Normalizes types where the server
+ * echoes them back differently (e.g., `earliest` can be a
+ * number when the plan uses a relative string; we compare
+ * stringified forms to keep the check tolerant). */
+function isSameAsPlan(want: ProvisionedSearch, cur: SavedSearchRow): boolean {
+  if (want.name !== cur.name) return false;
+  if (want.description !== cur.description) return false;
+  if (want.query !== cur.query) return false;
+  if (String(want.earliest) !== String(cur.earliest)) return false;
+  if (String(want.latest) !== String(cur.latest)) return false;
+  if ((want.sampleRate ?? 1) !== (cur.sampleRate ?? 1)) return false;
+  // schedule is a nested object — compare by JSON serialization.
+  // Overkill compared to a deep-equal, but stable enough for a
+  // small object and saves a dependency.
+  const serverSchedule =
+    cur.schedule && typeof cur.schedule === 'object'
+      ? (cur.schedule as Record<string, unknown>)
+      : {};
+  const wantSchedule: Record<string, unknown> = {
+    enabled: want.schedule.enabled,
+    cronSchedule: want.schedule.cronSchedule,
+    tz: want.schedule.tz,
+    keepLastN: want.schedule.keepLastN,
+  };
+  for (const key of Object.keys(wantSchedule)) {
+    if (wantSchedule[key] !== serverSchedule[key]) return false;
+  }
+  return true;
+}
+
+/** POST / PATCH / DELETE executor. Returns a per-action result
+ * so the caller can print a summary and detect partial failure. */
+export interface ActionResult {
+  action: PlanAction;
+  ok: boolean;
+  error?: string;
+}
+
+export async function applyProvisioningPlan(
+  http: HttpClient,
+  actions: PlanAction[],
+): Promise<ActionResult[]> {
+  const results: ActionResult[] = [];
+  for (const action of actions) {
+    try {
+      await executeAction(http, action);
+      results.push({ action, ok: true });
+    } catch (err) {
+      results.push({
+        action,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return results;
+}
+
+async function executeAction(
+  http: HttpClient,
+  action: PlanAction,
+): Promise<void> {
+  switch (action.kind) {
+    case 'create': {
+      const body = planToBody(action.want);
+      await http.post(savedSearchesPath(), body);
+      return;
+    }
+    case 'update': {
+      const body = planToBody(action.want);
+      await http.patch(savedSearchesPath(action.want.id), body);
+      return;
+    }
+    case 'delete': {
+      await http.del(savedSearchesPath(action.current.id));
+      return;
+    }
+    case 'noop':
+      return;
+  }
+}
+
+/** Convert a plan entry into the JSON body the server wants.
+ * The server auto-populates `user` and `displayUsername` on
+ * create, so we deliberately omit them. */
+function planToBody(want: ProvisionedSearch): Record<string, unknown> {
+  return {
+    id: want.id,
+    name: want.name,
+    description: want.description,
+    query: want.query,
+    earliest: want.earliest,
+    latest: want.latest,
+    sampleRate: want.sampleRate ?? 1,
+    schedule: {
+      enabled: want.schedule.enabled,
+      cronSchedule: want.schedule.cronSchedule,
+      tz: want.schedule.tz,
+      keepLastN: want.schedule.keepLastN,
+      // emptyNotifications / emptyAdvanced / notifications stay
+      // absent — we aren't attaching alerts to these background
+      // maintenance searches, just running them on a cron so the
+      // panel caches stay warm.
+    },
+  };
+}
+
+/** Top-level orchestrator: load the plan, list current rows,
+ * diff, apply. Returns a structured summary the caller can
+ * render however it likes. */
+export async function reconcile(http: HttpClient): Promise<{
+  plan: ProvisionedSearch[];
+  current: SavedSearchRow[];
+  actions: PlanAction[];
+  results: ActionResult[];
+}> {
+  const plan = getProvisioningPlan();
+  const current = await listProvisioned(http);
+  const actions = diffProvisioned(plan, current);
+  const results = await applyProvisioningPlan(http, actions);
+  return { plan, current, actions, results };
+}
+
+/** Dangerous: delete every `criblapm__*` saved search on the
+ * server, no questions asked. Kept separate from `reconcile()`
+ * so it can't be confused for an innocent "update". Used
+ * during dev cleanup and by a future Settings > Reset action. */
+export async function unprovisionAll(
+  http: HttpClient,
+): Promise<ActionResult[]> {
+  const current = await listProvisioned(http);
+  const actions: PlanAction[] = current.map((row) => ({
+    kind: 'delete' as const,
+    current: row,
+  }));
+  return applyProvisioningPlan(http, actions);
+}
+
+/** Dry-run helper: return the actions without applying them.
+ * Used by the script's --dry-run mode and by the eventual
+ * first-run dialog to show the user what the provisioner
+ * would do before they click Confirm. */
+export async function planOnly(http: HttpClient): Promise<{
+  plan: ProvisionedSearch[];
+  current: SavedSearchRow[];
+  actions: PlanAction[];
+}> {
+  const plan = getProvisioningPlan();
+  const current = await listProvisioned(http);
+  const actions = diffProvisioned(plan, current);
+  return { plan, current, actions };
+}
+
+/** Factory for the in-app HTTP client: wraps the browser's
+ * `fetch` against the platform-injected CRIBL_API_URL. The
+ * platform fetch proxy handles auth automatically. Thrown
+ * errors include the HTTP status and response body on
+ * non-2xx to make debugging saner. */
+export function createBrowserHttpClient(): HttpClient {
+  const base = (window.CRIBL_API_URL ?? '/api/v1').replace(/\/$/, '');
+  async function call(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<unknown> {
+    const resp = await fetch(base + path, {
+      method,
+      headers: body ? { 'content-type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      throw new Error(`${method} ${path} failed (${resp.status}): ${text.slice(0, 400)}`);
+    }
+    const ct = resp.headers.get('content-type') || '';
+    if (ct.includes('json')) return resp.json();
+    return resp.text();
+  }
+  return {
+    get: (p) => call('GET', p),
+    post: (p, b) => call('POST', p, b),
+    patch: (p, b) => call('PATCH', p, b),
+    del: (p) => call('DELETE', p),
+  };
+}

--- a/oteldemo/src/components/ProvisioningPanel.module.css
+++ b/oteldemo/src/components/ProvisioningPanel.module.css
@@ -1,0 +1,255 @@
+.card {
+  background: var(--cds-color-bg);
+  border: 1px solid var(--cds-color-border-subtle);
+  border-radius: var(--cds-radius-lg);
+  box-shadow: var(--cds-shadow-sm);
+  padding: var(--cds-space-lg);
+}
+
+.sectionTitle {
+  font-size: var(--cds-font-size-lg);
+  font-weight: var(--cds-font-weight-semibold);
+  color: var(--cds-color-fg);
+  margin: 0 0 var(--cds-space-sm) 0;
+}
+
+.sectionHelp {
+  font-size: var(--cds-font-size-sm);
+  color: var(--cds-color-fg-muted);
+  line-height: 1.5;
+  margin: 0 0 var(--cds-space-md) 0;
+}
+
+.actions {
+  display: flex;
+  gap: var(--cds-space-sm);
+  margin-top: var(--cds-space-md);
+  align-items: center;
+}
+
+.primaryBtn {
+  background: var(--cds-color-accent);
+  color: white;
+  border: none;
+  border-radius: var(--cds-radius-md);
+  padding: var(--cds-space-sm) var(--cds-space-lg);
+  font-size: var(--cds-font-size-sm);
+  font-weight: var(--cds-font-weight-semibold);
+  cursor: pointer;
+  transition: opacity var(--cds-transition-fast);
+}
+.primaryBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+.primaryBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.secondaryBtn {
+  background: transparent;
+  color: var(--cds-color-fg-muted);
+  border: 1px solid var(--cds-color-border-subtle);
+  border-radius: var(--cds-radius-md);
+  padding: var(--cds-space-sm) var(--cds-space-lg);
+  font-size: var(--cds-font-size-sm);
+  cursor: pointer;
+  transition: background var(--cds-transition-fast);
+}
+.secondaryBtn:hover {
+  background: var(--cds-color-bg-subtle);
+}
+
+.statusLine {
+  font-size: var(--cds-font-size-sm);
+  color: var(--cds-color-fg-muted);
+  padding: var(--cds-space-md) 0;
+}
+
+.errorBox {
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid var(--cds-color-danger);
+  border-radius: var(--cds-radius-md);
+  padding: var(--cds-space-md);
+  color: var(--cds-color-danger);
+  font-size: var(--cds-font-size-sm);
+  margin-top: var(--cds-space-md);
+}
+
+.errText {
+  color: var(--cds-color-danger);
+  font-size: var(--cds-font-size-xs);
+  margin-left: var(--cds-space-sm);
+}
+
+/* -------- Action summary chips -------- */
+
+.summary {
+  display: flex;
+  gap: var(--cds-space-md);
+  margin: var(--cds-space-md) 0;
+}
+
+.summaryChip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--cds-space-sm);
+  padding: var(--cds-space-sm) var(--cds-space-md);
+  border-radius: var(--cds-radius-md);
+  border: 1px solid var(--cds-color-border-subtle);
+  font-size: var(--cds-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.summaryCount {
+  font-size: var(--cds-font-size-lg);
+  font-weight: var(--cds-font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+.summaryLabel {
+  color: var(--cds-color-fg-muted);
+}
+
+.summaryChip_create {
+  background: rgba(16, 185, 129, 0.08);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+.summaryChip_create .summaryCount {
+  color: #10b981;
+}
+
+.summaryChip_update {
+  background: rgba(59, 130, 246, 0.08);
+  border-color: rgba(59, 130, 246, 0.3);
+}
+.summaryChip_update .summaryCount {
+  color: #3b82f6;
+}
+
+.summaryChip_delete {
+  background: rgba(220, 38, 38, 0.08);
+  border-color: rgba(220, 38, 38, 0.3);
+}
+.summaryChip_delete .summaryCount {
+  color: var(--cds-color-danger);
+}
+
+.summaryChip_noop {
+  background: var(--cds-color-bg-subtle);
+}
+
+/* -------- Action list -------- */
+
+.actionList {
+  list-style: none;
+  padding: 0;
+  margin: var(--cds-space-md) 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 420px;
+  overflow-y: auto;
+  border: 1px solid var(--cds-color-border-subtle);
+  border-radius: var(--cds-radius-md);
+}
+
+.actionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--cds-space-md);
+  padding: var(--cds-space-sm) var(--cds-space-md);
+  font-size: var(--cds-font-size-sm);
+  border-bottom: 1px solid var(--cds-color-border-subtle);
+}
+.actionRow:last-child {
+  border-bottom: none;
+}
+
+.actionKind {
+  display: inline-block;
+  min-width: 56px;
+  padding: 2px var(--cds-space-sm);
+  border-radius: var(--cds-radius-sm);
+  font-size: var(--cds-font-size-xs);
+  font-weight: var(--cds-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  text-align: center;
+}
+.actionKind_create {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+}
+.actionKind_update {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+.actionKind_delete {
+  background: rgba(220, 38, 38, 0.15);
+  color: var(--cds-color-danger);
+}
+.actionKind_noop {
+  background: var(--cds-color-bg-subtle);
+  color: var(--cds-color-fg-muted);
+}
+
+.actionId {
+  font-family: var(--cds-font-mono, monospace);
+  color: var(--cds-color-fg);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* -------- Danger zone -------- */
+
+.dangerZone {
+  margin-top: var(--cds-space-xl);
+  padding-top: var(--cds-space-lg);
+  border-top: 1px dashed var(--cds-color-border-subtle);
+}
+
+.dangerTitle {
+  font-size: var(--cds-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--cds-color-danger);
+  font-weight: var(--cds-font-weight-semibold);
+}
+
+.dangerHelp {
+  font-size: var(--cds-font-size-sm);
+  color: var(--cds-color-fg-muted);
+  line-height: 1.5;
+  margin: var(--cds-space-sm) 0 var(--cds-space-md) 0;
+}
+
+.dangerBtn {
+  background: transparent;
+  color: var(--cds-color-danger);
+  border: 1px solid var(--cds-color-danger);
+  border-radius: var(--cds-radius-md);
+  padding: var(--cds-space-sm) var(--cds-space-lg);
+  font-size: var(--cds-font-size-sm);
+  cursor: pointer;
+  transition: background var(--cds-transition-fast);
+  margin-right: var(--cds-space-sm);
+}
+.dangerBtn:hover {
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.dangerBtnConfirm {
+  background: var(--cds-color-danger);
+  color: white;
+  border: 1px solid var(--cds-color-danger);
+  border-radius: var(--cds-radius-md);
+  padding: var(--cds-space-sm) var(--cds-space-lg);
+  font-size: var(--cds-font-size-sm);
+  font-weight: var(--cds-font-weight-semibold);
+  cursor: pointer;
+  margin-right: var(--cds-space-sm);
+}

--- a/oteldemo/src/components/ProvisioningPanel.tsx
+++ b/oteldemo/src/components/ProvisioningPanel.tsx
@@ -1,0 +1,332 @@
+/**
+ * Settings-page section that reconciles Cribl APM's scheduled
+ * saved searches against the workspace. Three states:
+ *
+ *   idle      — nothing loaded yet; "Preview plan" button visible.
+ *   preview   — fetched the plan + diff; shows a list of
+ *               Create/Update/Delete/Noop actions. "Apply" button
+ *               becomes live.
+ *   applying  — reconcile in progress.
+ *   results   — each action's ok/error rendered inline.
+ *
+ * The same component is the skeleton for the §2e first-run
+ * provisioning dialog: the preview → apply flow is the thing the
+ * user sees once on install, and it lives here permanently for
+ * re-provisioning after a dataset change or a pack upgrade.
+ *
+ * There's also an "Unprovision all" escape hatch for dev / reset
+ * scenarios. Requires a confirmation click because it deletes
+ * every `criblapm__*` saved search on the workspace.
+ */
+import { useState } from 'react';
+import {
+  createBrowserHttpClient,
+  planOnly,
+  applyProvisioningPlan,
+  unprovisionAll,
+  type PlanAction,
+  type ActionResult,
+  type SavedSearchRow,
+} from '../api/provisioner';
+import type { ProvisionedSearch } from '../api/provisionedSearches';
+import s from './ProvisioningPanel.module.css';
+
+type PanelState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | {
+      kind: 'preview';
+      plan: ProvisionedSearch[];
+      current: SavedSearchRow[];
+      actions: PlanAction[];
+    }
+  | {
+      kind: 'applying';
+      actions: PlanAction[];
+    }
+  | {
+      kind: 'results';
+      results: ActionResult[];
+    }
+  | {
+      kind: 'error';
+      error: string;
+    };
+
+function countByKind(actions: PlanAction[]): Record<PlanAction['kind'], number> {
+  const counts: Record<PlanAction['kind'], number> = {
+    create: 0,
+    update: 0,
+    delete: 0,
+    noop: 0,
+  };
+  for (const a of actions) counts[a.kind]++;
+  return counts;
+}
+
+function actionLabel(action: PlanAction): string {
+  switch (action.kind) {
+    case 'create':
+      return action.want.id;
+    case 'update':
+      return action.want.id;
+    case 'delete':
+      return action.current.id;
+    case 'noop':
+      return action.want.id;
+  }
+}
+
+export default function ProvisioningPanel() {
+  const [state, setState] = useState<PanelState>({ kind: 'idle' });
+  const [confirmUnprovision, setConfirmUnprovision] = useState(false);
+
+  async function handlePreview() {
+    setState({ kind: 'loading' });
+    try {
+      const http = createBrowserHttpClient();
+      const { plan, current, actions } = await planOnly(http);
+      setState({ kind: 'preview', plan, current, actions });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleApply() {
+    if (state.kind !== 'preview') return;
+    const actions = state.actions;
+    setState({ kind: 'applying', actions });
+    try {
+      const http = createBrowserHttpClient();
+      const results = await applyProvisioningPlan(http, actions);
+      setState({ kind: 'results', results });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleUnprovision() {
+    if (!confirmUnprovision) {
+      setConfirmUnprovision(true);
+      return;
+    }
+    setConfirmUnprovision(false);
+    setState({ kind: 'loading' });
+    try {
+      const http = createBrowserHttpClient();
+      const results = await unprovisionAll(http);
+      setState({ kind: 'results', results });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <div className={s.card}>
+      <h2 className={s.sectionTitle}>Scheduled searches</h2>
+      <p className={s.sectionHelp}>
+        Cribl APM caches its expensive panel queries (Home catalog,
+        sparklines, slow trace classes, error classes, dependency
+        graph, latency baselines) as scheduled Cribl Saved Searches
+        that run every few minutes. Pages then read the cached rows
+        via <code>$vt_results</code> / lookup joins, which is ~10×
+        faster than running the underlying queries live on every
+        load. Re-run the preview after changing the{' '}
+        <strong>Dataset</strong> or <strong>Noise filters</strong>{' '}
+        setting so the cached queries pick up the new values.
+      </p>
+
+      {state.kind === 'idle' && (
+        <div className={s.actions}>
+          <button type="button" className={s.primaryBtn} onClick={handlePreview}>
+            Preview plan
+          </button>
+        </div>
+      )}
+
+      {state.kind === 'loading' && (
+        <div className={s.statusLine}>Loading plan…</div>
+      )}
+
+      {state.kind === 'error' && (
+        <>
+          <div className={s.errorBox}>
+            <strong>Error:</strong> {state.error}
+          </div>
+          <div className={s.actions}>
+            <button
+              type="button"
+              className={s.secondaryBtn}
+              onClick={() => setState({ kind: 'idle' })}
+            >
+              Dismiss
+            </button>
+          </div>
+        </>
+      )}
+
+      {state.kind === 'preview' && <PreviewView state={state} onApply={handleApply} onCancel={() => setState({ kind: 'idle' })} />}
+
+      {state.kind === 'applying' && (
+        <div className={s.statusLine}>
+          Applying {state.actions.filter((a) => a.kind !== 'noop').length} change(s)…
+        </div>
+      )}
+
+      {state.kind === 'results' && (
+        <ResultsView
+          results={state.results}
+          onDone={() => setState({ kind: 'idle' })}
+        />
+      )}
+
+      {/* Danger zone: always visible so it's accessible from any state,
+          but gated by a two-click confirmation to make it impossible
+          to delete everything by accident. */}
+      <div className={s.dangerZone}>
+        <div className={s.dangerTitle}>Danger zone</div>
+        <p className={s.dangerHelp}>
+          Deletes every <code>criblapm__*</code> saved search from the
+          workspace. Page loads revert to live queries (slower). Use
+          before reinstalling the pack or to fully reset state.
+        </p>
+        <button
+          type="button"
+          className={confirmUnprovision ? s.dangerBtnConfirm : s.dangerBtn}
+          onClick={handleUnprovision}
+        >
+          {confirmUnprovision ? 'Click again to confirm' : 'Unprovision all'}
+        </button>
+        {confirmUnprovision && (
+          <button
+            type="button"
+            className={s.secondaryBtn}
+            onClick={() => setConfirmUnprovision(false)}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PreviewView({
+  state,
+  onApply,
+  onCancel,
+}: {
+  state: { plan: ProvisionedSearch[]; current: SavedSearchRow[]; actions: PlanAction[] };
+  onApply: () => void;
+  onCancel: () => void;
+}) {
+  const counts = countByKind(state.actions);
+  const hasChanges = counts.create + counts.update + counts.delete > 0;
+  return (
+    <div>
+      <div className={s.summary}>
+        <SummaryChip kind="create" count={counts.create} label="Create" />
+        <SummaryChip kind="update" count={counts.update} label="Update" />
+        <SummaryChip kind="delete" count={counts.delete} label="Delete" />
+        <SummaryChip kind="noop" count={counts.noop} label="Unchanged" />
+      </div>
+
+      <ul className={s.actionList}>
+        {state.actions.map((action) => (
+          <li key={actionLabel(action)} className={s.actionRow}>
+            <span className={`${s.actionKind} ${s[`actionKind_${action.kind}`]}`}>
+              {action.kind}
+            </span>
+            <span className={s.actionId}>{actionLabel(action)}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div className={s.actions}>
+        <button
+          type="button"
+          className={s.primaryBtn}
+          onClick={onApply}
+          disabled={!hasChanges}
+        >
+          {hasChanges ? 'Apply' : 'Nothing to do'}
+        </button>
+        <button type="button" className={s.secondaryBtn} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SummaryChip({
+  kind,
+  count,
+  label,
+}: {
+  kind: PlanAction['kind'];
+  count: number;
+  label: string;
+}) {
+  return (
+    <span className={`${s.summaryChip} ${s[`summaryChip_${kind}`]}`}>
+      <span className={s.summaryCount}>{count}</span>
+      <span className={s.summaryLabel}>{label}</span>
+    </span>
+  );
+}
+
+function ResultsView({
+  results,
+  onDone,
+}: {
+  results: ActionResult[];
+  onDone: () => void;
+}) {
+  const failures = results.filter((r) => !r.ok);
+  const okCount = results.filter((r) => r.ok).length;
+  return (
+    <div>
+      <div className={s.statusLine}>
+        {failures.length === 0 ? (
+          <>All {okCount} action(s) applied cleanly.</>
+        ) : (
+          <>
+            {okCount} succeeded, <strong className={s.errText}>{failures.length} failed</strong>.
+          </>
+        )}
+      </div>
+      <ul className={s.actionList}>
+        {results.map((r) => (
+          <li key={actionLabel(r.action)} className={s.actionRow}>
+            <span
+              className={`${s.actionKind} ${
+                r.ok ? s.actionKind_noop : s.actionKind_delete
+              }`}
+            >
+              {r.ok ? 'ok' : 'fail'}
+            </span>
+            <span className={s.actionId}>
+              {r.action.kind}: {actionLabel(r.action)}
+            </span>
+            {r.error && <span className={s.errText}>{r.error}</span>}
+          </li>
+        ))}
+      </ul>
+      <div className={s.actions}>
+        <button type="button" className={s.primaryBtn} onClick={onDone}>
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/oteldemo/src/routes/SettingsPage.tsx
+++ b/oteldemo/src/routes/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import StatusBanner from '../components/StatusBanner';
+import ProvisioningPanel from '../components/ProvisioningPanel';
 import { saveAppSettings } from '../api/appSettings';
 import { setCurrentDataset } from '../api/dataset';
 import { setStreamFilterEnabled } from '../api/streamFilter';
@@ -207,6 +208,8 @@ export default function SettingsPage() {
           </div>
         </label>
       </div>
+
+      <ProvisioningPanel />
     </div>
   );
 }


### PR DESCRIPTION
**Declarative inventory of the seven scheduled Cribl saved searches Cribl APM needs, a reconciler module that upserts them, and a Settings page UI panel that runs the reconciler with a Preview → Apply flow. Foundation for PRs #7 and #8.**

## Commits

- \`22ff785\` — \`provisionedSearches.ts\` (declarative list) + \`provisioner.ts\` (reconciler: listProvisioned / diffProvisioned / applyProvisioningPlan / unprovisionAll). HttpClient abstraction so the same core runs inside the browser or from a node driver. No behavior change yet.
- \`be31041\` — \`ProvisioningPanel\` component wired into Settings. Preview plan → shows create/update/delete/noop counts + per-row action list → Apply button. Two-click danger zone for Unprovision-all.
- \`e8cef57\` — tiny fix: the server rejects em-dashes in saved-search names (validation pattern \`^[a-zA-Z0-9 _-]+$\`), replaced with regular hyphens.

## What gets provisioned

| ID | Source | Cron |
|---|---|---|
| \`criblapm__home_service_summary\` | \`Q.serviceSummary()\` | every 5 min |
| \`criblapm__home_service_time_series\` | \`Q.serviceTimeSeries(60)\` | every 5 min |
| \`criblapm__home_slow_traces\` | \`Q.rawSlowestTraces(500)\` | every 5 min |
| \`criblapm__home_error_spans\` | \`Q.rawRecentErrorSpans(300)\` | every 5 min |
| \`criblapm__sysarch_dependencies\` | \`Q.dependencies()\` | every 5 min |
| \`criblapm__sysarch_messaging_deps\` | \`Q.messagingDependencies()\` | every 5 min |
| \`criblapm__op_baselines\` | 24h per-op baseline with `\| export mode=overwrite to lookup criblapm_op_baselines\` | hourly |

## Validate from your phone

Visit https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/settings (or click the gear icon from any page).

Scroll to the **Scheduled searches** card. Click **Preview plan** — should show:

**7 unchanged** (everything already provisioned; idempotent).

If you want to poke the danger zone: click **Unprovision all** once, get the "Click again to confirm" state, click **Cancel** to back out. Don't actually unprovision — PRs #7 and #8 depend on the searches existing.

![Provisioning preview view](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/03-settings-provisioning-preview.png)

![Provisioning applied view](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/04-settings-provisioning-applied.png)

## Safety model

Only rows whose ID starts with \`criblapm__\` are ever touched by the reconciler. User-created saved searches are invisible to this module. Prefix-based idempotence — no list-then-diff-and-hope-for-the-best.

## Context

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)