### PR TITLE
oteldemo: Home + System Architecture read panel data from $vt_results cache

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -234,18 +234,20 @@ read: `dataset="$vt_results" jobName="criblapm__panel_name"`.
 No explicit `| export` step, no role restrictions, no 10k row
 cap to worry about for time-series.
 
-**The killer optimization**: `jobName` accepts an **array**.
+**The killer optimization**: one batched read returns every
+cached panel in a single search job. The docs advertise an
+inline array literal (`jobName=[...]`) but it doesn't actually
+parse; the working form is `| where jobName in (...)`:
 ```kql
 dataset="$vt_results"
-  jobName=["criblapm__home_service_summary",
-           "criblapm__home_service_time_series",
-           "criblapm__home_slow_traces",
-           "criblapm__home_error_spans"]
+  | where jobName in ("criblapm__home_service_summary",
+                       "criblapm__home_service_time_series",
+                       "criblapm__home_slow_traces",
+                       "criblapm__home_error_spans")
 ```
-This returns all four cached panels in **one** search job. Each
-row comes back auto-tagged with `jobName`, so the client just
-partitions the result stream by that column and hands each
-partition to its panel.
+Each row comes back auto-tagged with `jobName`, so the client
+just partitions the result stream by that column and hands
+each partition to its panel.
 
 Today the Home page fires 5–7 independent panel queries, each
 paying ~500ms of queue wait before it can execute. End-to-end

--- a/docs/research/cribl-saved-searches.md
+++ b/docs/research/cribl-saved-searches.md
@@ -217,17 +217,30 @@ dataset="$vt_results" jobName="my_saved_search"
 dataset="$vt_results" jobName="my_saved_search" execution=-1
 // or all history:
 dataset="$vt_results" jobName="my_saved_search" execution=*
-// or by explicit job ID (supports arrays):
-dataset="$vt_results" jobId=["id1","id2"]
-// and — the killer — multiple named saved searches at once:
-dataset="$vt_results" jobName=["panel_a","panel_b","panel_c"]
+// or by explicit job ID:
+dataset="$vt_results" jobId="1704236905683.wgocax"
 ```
 
-The `jobName` array form is the key enabler for **batch panel
-reads**: one search job pulls the cached row sets of every
-panel on the page, partitioned client-side by the auto-
-populated `jobName` column on each row. See §2b.2 of the
-ROADMAP for the full rationale.
+**Batch reads across multiple named searches** use an `in (...)`
+filter instead of the advertised array literal. The docs at
+[docs.cribl.io/search/vt_results](https://docs.cribl.io/search/vt_results/)
+show `jobName=["a","b"]` as the array form, but Cribl KQL does
+not actually parse the array literal in the top-of-pipeline
+position. Empirically:
+
+```kql
+// FAILS with "no viable alternative at input 'jobName=['":
+dataset="$vt_results" jobName=["panel_a","panel_b"]
+
+// WORKS — returns the union of rows from both searches:
+dataset="$vt_results"
+  | where jobName in ("panel_a", "panel_b", "panel_c")
+```
+
+Both reads return one row per cached result row, with the
+`jobName` column auto-populated so the client can partition
+the mixed stream client-side. See §2b.2 of the ROADMAP for
+the full rationale on why this batching is load-bearing.
 
 **Write**: free, automatic — every scheduled run retains its
 results with no `| export` or `| send` step needed.

--- a/oteldemo/src/api/panelCache.ts
+++ b/oteldemo/src/api/panelCache.ts
@@ -30,50 +30,34 @@ import {
   getSystemArchPanelJobNames,
 } from './provisionedSearches';
 import { groupSlowTraceClasses, groupErrorClasses } from './search';
+import { toDependencyEdges, toMessagingEdges } from './transform';
 import type {
   ServiceSummary,
   ServiceBucket,
   SlowTraceClass,
   ErrorClass,
+  DependencyEdge,
 } from './types';
 
 /** Panels any Cribl APM page can pull from the cache. When a
- * page only needs a subset (e.g. Home doesn't need messaging
- * dependencies) it simply ignores the extra keys. */
+ * page only needs a subset (e.g. Home doesn't need dependency
+ * edges) it simply ignores the extra keys.
+ *
+ * The `dependencies` field is the pre-merged DependencyEdge[] —
+ * RPC edges (via Q.dependencies) + messaging edges (via
+ * Q.messagingDependencies) glued together the same way
+ * `search.ts::getDependencies` does at runtime. The cache
+ * consumer gets the exact same shape as the live path. */
 export interface CachedPanels {
   serviceSummaries: ServiceSummary[] | null;
   serviceBuckets: ServiceBucket[] | null;
   slowClasses: SlowTraceClass[] | null;
   errorClasses: ErrorClass[] | null;
-  dependencies: DependencyEdgeRow[] | null;
-  messagingDependencies: MessagingEdgeRow[] | null;
+  dependencies: DependencyEdge[] | null;
   /** Latest bucket timestamp observed across the cached panels,
    * in milliseconds since epoch. Used by the UI to render a
    * "Cached N s ago" indicator. Null if nothing cached. */
   lastUpdatedMs: number | null;
-}
-
-/** Raw row shapes returned by the scheduled searches. These are
- * thin — they match what `Q.dependencies()` and
- * `Q.messagingDependencies()` produce at the KQL level and get
- * handed to `transform.ts::toDependencyEdges` /
- * `toMessagingEdges` for final mapping. */
-export interface DependencyEdgeRow {
-  parent: string;
-  child: string;
-  callCount: number;
-  errorCount: number;
-  p95DurUs: number;
-}
-
-export interface MessagingEdgeRow {
-  svc: string;
-  msg_dest: string;
-  msg_op: string;
-  msg_system?: string;
-  spans: number;
-  errors: number;
-  p95_us: number;
 }
 
 function toNum(v: unknown): number {
@@ -161,34 +145,19 @@ function parseServiceBuckets(
   }));
 }
 
-/** Parse the dependency-edge partition. Raw shape matches what
- * Q.dependencies() emits. */
-function parseDependencyEdges(
-  rows: Record<string, unknown>[],
-): DependencyEdgeRow[] {
-  return rows.map((r) => ({
-    parent: String(r.parent ?? ''),
-    child: String(r.child ?? ''),
-    callCount: toNum(r.callCount),
-    errorCount: toNum(r.errorCount),
-    p95DurUs: toNum(r.p95DurUs),
-  }));
-}
-
-/** Parse the messaging-edge partition. Raw shape matches what
- * Q.messagingDependencies() emits. */
-function parseMessagingEdges(
-  rows: Record<string, unknown>[],
-): MessagingEdgeRow[] {
-  return rows.map((r) => ({
-    svc: String(r.svc ?? ''),
-    msg_dest: String(r.msg_dest ?? ''),
-    msg_op: String(r.msg_op ?? ''),
-    msg_system: r.msg_system ? String(r.msg_system) : undefined,
-    spans: toNum(r.spans),
-    errors: toNum(r.errors),
-    p95_us: toNum(r.p95_us),
-  }));
+/** Parse + merge RPC and messaging dependency partitions into
+ * the same DependencyEdge[] shape `search.ts::getDependencies`
+ * returns. Either partition may be null if that scheduled
+ * search hasn't run yet; callers get a partial edge list in
+ * that case rather than an error. */
+function mergeDependencyEdges(
+  rpcRows: Record<string, unknown>[] | null,
+  msgRows: Record<string, unknown>[] | null,
+): DependencyEdge[] | null {
+  if (!rpcRows && !msgRows) return null;
+  const rpc = rpcRows ? toDependencyEdges(rpcRows) : [];
+  const msg = msgRows ? toMessagingEdges(msgRows) : [];
+  return [...rpc, ...msg];
 }
 
 /**
@@ -246,8 +215,7 @@ function buildCachedPanels(
     serviceBuckets: timeSeriesRows ? parseServiceBuckets(timeSeriesRows) : null,
     slowClasses: slowRows ? groupSlowTraceClasses(slowRows) : null,
     errorClasses: errorRows ? groupErrorClasses(errorRows) : null,
-    dependencies: depRows ? parseDependencyEdges(depRows) : null,
-    messagingDependencies: msgDepRows ? parseMessagingEdges(msgDepRows) : null,
+    dependencies: mergeDependencyEdges(depRows, msgDepRows),
     lastUpdatedMs,
   };
 }

--- a/oteldemo/src/api/panelCache.ts
+++ b/oteldemo/src/api/panelCache.ts
@@ -1,0 +1,253 @@
+/**
+ * Panel cache reader — uses `$vt_results` with a `jobName=[...]`
+ * array to batch-read every Cribl APM Home and System Architecture
+ * panel in a single Cribl Search job. Partitions the mixed result
+ * stream client-side by the auto-populated `jobName` column on
+ * each row and hands each partition to the existing grouping /
+ * parsing helpers in `search.ts`.
+ *
+ * Why this exists: the live panel queries are expensive (full
+ * span aggregation per page load) AND each one pays ~500 ms of
+ * queue wait in the Cribl Search worker pool, so a home page with
+ * 5 panels used to cost 8–15 s end-to-end. The scheduled searches
+ * set up by the provisioner persist the aggregated rows into
+ * `$vt_results`; this reader serves them back in ~1 s total.
+ *
+ * Cache miss semantics: if the scheduled search hasn't run yet
+ * (fresh install, dataset just changed) or the range on the page
+ * isn't the 1h default the searches are scheduled for, the
+ * reader returns `null` for that panel and the caller falls back
+ * to the live query. Cache miss is a graceful degradation, not
+ * an error.
+ *
+ * See ROADMAP §2b.2 for the full rationale and
+ * `docs/research/cribl-saved-searches.md` for empirical timing
+ * numbers that motivate this design.
+ */
+import { runQuery } from './cribl';
+import {
+  getHomePanelJobNames,
+  getSystemArchPanelJobNames,
+} from './provisionedSearches';
+import { groupSlowTraceClasses, groupErrorClasses } from './search';
+import type {
+  ServiceSummary,
+  ServiceBucket,
+  SlowTraceClass,
+  ErrorClass,
+} from './types';
+
+/** Panels any Cribl APM page can pull from the cache. When a
+ * page only needs a subset (e.g. Home doesn't need messaging
+ * dependencies) it simply ignores the extra keys. */
+export interface CachedPanels {
+  serviceSummaries: ServiceSummary[] | null;
+  serviceBuckets: ServiceBucket[] | null;
+  slowClasses: SlowTraceClass[] | null;
+  errorClasses: ErrorClass[] | null;
+  dependencies: DependencyEdgeRow[] | null;
+  messagingDependencies: MessagingEdgeRow[] | null;
+  /** Latest bucket timestamp observed across the cached panels,
+   * in milliseconds since epoch. Used by the UI to render a
+   * "Cached N s ago" indicator. Null if nothing cached. */
+  lastUpdatedMs: number | null;
+}
+
+/** Raw row shapes returned by the scheduled searches. These are
+ * thin — they match what `Q.dependencies()` and
+ * `Q.messagingDependencies()` produce at the KQL level and get
+ * handed to `transform.ts::toDependencyEdges` /
+ * `toMessagingEdges` for final mapping. */
+export interface DependencyEdgeRow {
+  parent: string;
+  child: string;
+  callCount: number;
+  errorCount: number;
+  p95DurUs: number;
+}
+
+export interface MessagingEdgeRow {
+  svc: string;
+  msg_dest: string;
+  msg_op: string;
+  msg_system?: string;
+  spans: number;
+  errors: number;
+  p95_us: number;
+}
+
+function toNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Issue a single $vt_results query covering every panel in
+ * `jobNames`, then partition the mixed row stream by the
+ * auto-populated `jobName` column. Returns a Map keyed by
+ * jobName (with arrays of raw rows as values) so the caller
+ * can decide what to do with each partition.
+ */
+async function readCachedPanelsRaw(
+  jobNames: string[],
+): Promise<Map<string, Record<string, unknown>[]>> {
+  if (jobNames.length === 0) return new Map();
+  // Build the jobName `in (...)` clause. Quotes are safe because
+  // job names match ^[a-zA-Z0-9 _-]+$.
+  //
+  // NOTE on syntax: the docs at docs.cribl.io/search/vt_results
+  // advertise `jobName=["a","b"]` as an inline array literal,
+  // but Cribl KQL does not actually parse that form in the
+  // top-of-pipeline position (verified empirically — it returns
+  // `no viable alternative at input 'jobName=['`). The working
+  // equivalent is a `| where jobName in (...)` filter, which
+  // returns the correct union of rows across all named searches.
+  const jobNameList = jobNames.map((n) => `"${n}"`).join(', ');
+  // The $vt_results dataset is global — no datasetClause() needed.
+  // Latest bucket timestamp across all scheduled runs lives in the
+  // events, so we don't need a long earliest window. Still, allow
+  // up to 1h in case a schedule slipped.
+  const query = `dataset="$vt_results" | where jobName in (${jobNameList})`;
+  // Panel caches can be large: the time-series panel alone is ~60
+  // buckets × ~20 services = 1,200 rows. Seven panels together can
+  // push 3,000+ rows. Use a generous limit so nothing is truncated.
+  const rows = await runQuery(query, '-1h', 'now', 10_000);
+
+  const out = new Map<string, Record<string, unknown>[]>();
+  for (const row of rows) {
+    const jn = String(row.jobName ?? '');
+    if (!jn) continue;
+    let bucket = out.get(jn);
+    if (!bucket) {
+      bucket = [];
+      out.set(jn, bucket);
+    }
+    bucket.push(row);
+  }
+  return out;
+}
+
+/** Parse the service-summary partition into ServiceSummary[]. */
+function parseServiceSummaries(
+  rows: Record<string, unknown>[],
+): ServiceSummary[] {
+  return rows.map((r) => {
+    const requests = toNum(r.requests);
+    const errors = toNum(r.errors);
+    return {
+      service: String(r.svc ?? 'unknown'),
+      requests,
+      errors,
+      errorRate: toNum(r.error_rate),
+      p50Us: toNum(r.p50_us),
+      p95Us: toNum(r.p95_us),
+      p99Us: toNum(r.p99_us),
+    };
+  });
+}
+
+/** Parse the service-time-series partition into ServiceBucket[]. */
+function parseServiceBuckets(
+  rows: Record<string, unknown>[],
+): ServiceBucket[] {
+  return rows.map((r) => ({
+    service: String(r.svc ?? 'unknown'),
+    bucketMs: toNum(r.bucket) * 1000,
+    requests: toNum(r.requests),
+    errors: toNum(r.errors),
+    p50Us: toNum(r.p50_us),
+    p95Us: toNum(r.p95_us),
+    p99Us: toNum(r.p99_us),
+  }));
+}
+
+/** Parse the dependency-edge partition. Raw shape matches what
+ * Q.dependencies() emits. */
+function parseDependencyEdges(
+  rows: Record<string, unknown>[],
+): DependencyEdgeRow[] {
+  return rows.map((r) => ({
+    parent: String(r.parent ?? ''),
+    child: String(r.child ?? ''),
+    callCount: toNum(r.callCount),
+    errorCount: toNum(r.errorCount),
+    p95DurUs: toNum(r.p95DurUs),
+  }));
+}
+
+/** Parse the messaging-edge partition. Raw shape matches what
+ * Q.messagingDependencies() emits. */
+function parseMessagingEdges(
+  rows: Record<string, unknown>[],
+): MessagingEdgeRow[] {
+  return rows.map((r) => ({
+    svc: String(r.svc ?? ''),
+    msg_dest: String(r.msg_dest ?? ''),
+    msg_op: String(r.msg_op ?? ''),
+    msg_system: r.msg_system ? String(r.msg_system) : undefined,
+    spans: toNum(r.spans),
+    errors: toNum(r.errors),
+    p95_us: toNum(r.p95_us),
+  }));
+}
+
+/**
+ * Read all Home panel caches in one batched $vt_results query.
+ * Returns a `CachedPanels` struct with populated fields for every
+ * panel that had cached rows, and `null` for panels whose
+ * scheduled search hasn't run yet. The caller falls back to the
+ * live query path for any null field.
+ */
+export async function listCachedHomePanels(): Promise<CachedPanels> {
+  const names = getHomePanelJobNames();
+  const partitions = await readCachedPanelsRaw(names);
+  return buildCachedPanels(partitions);
+}
+
+/** Same pattern for the System Architecture view. Includes the
+ * Home-shared service summary + time series panels because the
+ * arch page reuses them; this way both pages benefit from the
+ * same scheduled runs. */
+export async function listCachedSysarchPanels(): Promise<CachedPanels> {
+  const names = getSystemArchPanelJobNames();
+  const partitions = await readCachedPanelsRaw(names);
+  return buildCachedPanels(partitions);
+}
+
+/** Shared partition → typed-struct builder. Any panel not present
+ * in the partition map stays null. */
+function buildCachedPanels(
+  partitions: Map<string, Record<string, unknown>[]>,
+): CachedPanels {
+  let lastUpdatedMs: number | null = null;
+  for (const rows of partitions.values()) {
+    for (const row of rows) {
+      const t = toNum(row._time) * 1000;
+      if (t > 0 && (lastUpdatedMs === null || t > lastUpdatedMs)) {
+        lastUpdatedMs = t;
+      }
+    }
+  }
+
+  const get = (name: string): Record<string, unknown>[] | null => {
+    const rows = partitions.get(name);
+    return rows && rows.length > 0 ? rows : null;
+  };
+
+  const summaryRows = get('criblapm__home_service_summary');
+  const timeSeriesRows = get('criblapm__home_service_time_series');
+  const slowRows = get('criblapm__home_slow_traces');
+  const errorRows = get('criblapm__home_error_spans');
+  const depRows = get('criblapm__sysarch_dependencies');
+  const msgDepRows = get('criblapm__sysarch_messaging_deps');
+
+  return {
+    serviceSummaries: summaryRows ? parseServiceSummaries(summaryRows) : null,
+    serviceBuckets: timeSeriesRows ? parseServiceBuckets(timeSeriesRows) : null,
+    slowClasses: slowRows ? groupSlowTraceClasses(slowRows) : null,
+    errorClasses: errorRows ? groupErrorClasses(errorRows) : null,
+    dependencies: depRows ? parseDependencyEdges(depRows) : null,
+    messagingDependencies: msgDepRows ? parseMessagingEdges(msgDepRows) : null,
+    lastUpdatedMs,
+  };
+}

--- a/oteldemo/src/api/search.ts
+++ b/oteldemo/src/api/search.ts
@@ -271,11 +271,24 @@ export async function listSlowTraceClasses(
   topClasses = 20,
 ): Promise<SlowTraceClass[]> {
   const rows = await runQuery(Q.rawSlowestTraces(rawLimit), earliest, latest, rawLimit);
+  return groupSlowTraceClasses(rows, topClasses);
+}
+
+/**
+ * Pure grouping logic used by both the live `listSlowTraceClasses`
+ * verb and the panel-cache partitioner. Expects rows with root_svc,
+ * root_op, trace_id, trace_dur_us as produced by
+ * `Q.rawSlowestTraces`.
+ */
+export function groupSlowTraceClasses(
+  rows: Record<string, unknown>[],
+  topClasses: number = 20,
+): SlowTraceClass[] {
   interface Acc {
     rootService: string;
     rootOperation: string;
     durations: number[];
-    traceIds: string[]; // sorted by duration as we go
+    traceIds: string[];
   }
   const groups = new Map<string, Acc>();
   for (const r of rows) {
@@ -295,8 +308,6 @@ export async function listSlowTraceClasses(
   }
   const classes: SlowTraceClass[] = [];
   for (const g of groups.values()) {
-    // Pair durations with trace_ids and sort so the first trace_id is the
-    // slowest exemplar.
     const paired = g.durations.map((d, i) => ({ d, id: g.traceIds[i] }));
     paired.sort((a, b) => b.d - a.d);
     const durs = paired.map((p) => p.d);
@@ -326,6 +337,18 @@ export async function listErrorClasses(
   topClasses = 20,
 ): Promise<ErrorClass[]> {
   const rows = await runQuery(Q.rawRecentErrorSpans(rawLimit), earliest, latest, rawLimit);
+  return groupErrorClasses(rows, topClasses);
+}
+
+/**
+ * Pure grouping logic shared by the live `listErrorClasses` verb
+ * and the panel-cache partitioner. Expects rows with svc, name,
+ * msg, trace_id, _time as produced by `Q.rawRecentErrorSpans`.
+ */
+export function groupErrorClasses(
+  rows: Record<string, unknown>[],
+  topClasses: number = 20,
+): ErrorClass[] {
   interface Acc {
     service: string;
     operation: string;
@@ -339,9 +362,6 @@ export async function listErrorClasses(
     const svc = String(r.svc ?? 'unknown');
     const op = String(r.name ?? 'unknown');
     const rawMsg = String(r.msg ?? '').trim();
-    // Normalize: take the first line and strip trailing whitespace; if
-    // empty, fall back to "(no status message)" so the grouping still
-    // has a stable key.
     const firstLine = rawMsg.split('\n')[0].trim();
     const msg = firstLine || '(no status message)';
     const t = toNum(r._time) * 1000;

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -11,6 +11,7 @@ import {
   listSlowTraceClasses,
   listErrorClasses,
 } from '../api/search';
+import { listCachedHomePanels } from '../api/panelCache';
 import { serviceColor } from '../utils/spans';
 import { serviceHealth, healthRowBg } from '../utils/health';
 import { previousWindow } from '../utils/timeRange';
@@ -132,8 +133,59 @@ export default function HomePage() {
     setLoadingSlow(true);
     setLoadingErrors(true);
 
-    // Fan out — we want the table to populate as soon as summaries arrive,
-    // and the sparklines + bottom panels to fill in independently.
+    // Previous window of the same length — fuels the delta-vs-baseline
+    // chips. Failure here is non-fatal; we just skip the chips. Fired
+    // unconditionally because it's not part of the cacheable set
+    // (the prior window changes with every user range pick).
+    const prev = previousWindow(range);
+    const pPrevSummaries = listServiceSummaries(prev.earliest, prev.latest)
+      .then((r) => setPrevSummaries(r))
+      .catch(() => setPrevSummaries([]));
+
+    // Cache-fast path: when the user is on the default -1h range,
+    // try a single batched $vt_results read for all four panels
+    // before firing the live queries. A full cache hit returns
+    // ~1 s end-to-end instead of the 8-15 s the live path needs.
+    // Any miss (cache not populated, scheduled search hasn't run,
+    // partial panel failure) transparently falls through to the
+    // live queries.
+    //
+    // Stream-filter state is baked into the scheduled queries at
+    // provision time, so when the user toggles the stream filter
+    // we skip the cache too — otherwise they'd see stale filtered
+    // data until the next scheduled run + re-provision.
+    if (range === '-1h' && streamFilterEnabled) {
+      try {
+        const cached = await listCachedHomePanels();
+        if (
+          cached.serviceSummaries &&
+          cached.serviceBuckets &&
+          cached.slowClasses &&
+          cached.errorClasses
+        ) {
+          setSummaries(cached.serviceSummaries);
+          setBuckets(cached.serviceBuckets);
+          setSlowClasses(cached.slowClasses);
+          setErrorClasses(cached.errorClasses);
+          setLoadingSummaries(false);
+          setLoadingBuckets(false);
+          setLoadingSlow(false);
+          setLoadingErrors(false);
+          // Don't await the prev summary here — let it resolve in
+          // the background and light up the delta chips when it
+          // lands. The main catalog is already usable.
+          setLastRefresh(Date.now());
+          return;
+        }
+      } catch {
+        // Cache read failed — fall through to live fetch. Common on
+        // fresh installs before the first scheduled run lands.
+      }
+    }
+
+    // Fan out live queries — either because the user picked a
+    // non-default range, flipped off the stream filter, or because
+    // the cache came back empty.
     const pSummaries = listServiceSummaries(range, 'now')
       .then((r) => setSummaries(r))
       .catch((e: unknown) => {
@@ -141,13 +193,6 @@ export default function HomePage() {
         setSummaries([]);
       })
       .finally(() => setLoadingSummaries(false));
-
-    // Previous window of the same length — fuels the delta-vs-baseline
-    // chips. Failure here is non-fatal; we just skip the chips.
-    const prev = previousWindow(range);
-    const pPrevSummaries = listServiceSummaries(prev.earliest, prev.latest)
-      .then((r) => setPrevSummaries(r))
-      .catch(() => setPrevSummaries([]));
 
     const pBuckets = getServiceTimeSeries(binSeconds, undefined, range, 'now')
       .then((r) => setBuckets(r))
@@ -166,12 +211,9 @@ export default function HomePage() {
 
     await Promise.allSettled([pSummaries, pPrevSummaries, pBuckets, pSlow, pErrors]);
     setLastRefresh(Date.now());
-    // streamFilterEnabled is intentionally in the dep list — the
-    // queries pick it up from module state at build time, but the
-    // callback itself doesn't reference it. Including it here gives
-    // the useEffect below a fresh `fetchAll` identity when the user
-    // toggles the filter in Settings, which triggers a re-fetch.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // streamFilterEnabled is in the dep list so (a) flipping the
+    // toggle triggers a re-fetch and (b) the cache-fast path
+    // above reads the current value directly.
   }, [range, streamFilterEnabled]);
 
   // Initial load + on range change

--- a/oteldemo/src/routes/SystemArchPage.tsx
+++ b/oteldemo/src/routes/SystemArchPage.tsx
@@ -10,8 +10,10 @@ import {
   getServiceTimeSeries,
   listOperationSummaries,
 } from '../api/search';
+import { listCachedSysarchPanels } from '../api/panelCache';
 import { binSecondsFor } from '../components/timeRanges';
 import { previousWindow } from '../utils/timeRange';
+import { useStreamFilterEnabled } from '../hooks/useStreamFilter';
 import { HEALTH_LEGEND, serviceHealth } from '../utils/health';
 import type {
   DependencyEdge,
@@ -52,6 +54,7 @@ export default function SystemArchPage() {
   const [loadingDeps, setLoadingDeps] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dims, setDims] = useState({ w: 800, h: 600 });
+  const streamFilterEnabled = useStreamFilterEnabled();
 
   // Track container size for the SVG
   useEffect(() => {
@@ -64,39 +67,19 @@ export default function SystemArchPage() {
     return () => ro.disconnect();
   }, []);
 
-  // Fetch dependencies + service stats + time-series in parallel
+  // Fetch dependencies + service stats + time-series. Tries the
+  // batched $vt_results cache first when the user is on -1h and
+  // the stream filter is on; falls through to live queries on
+  // cache miss or non-default range.
   useEffect(() => {
     let cancelled = false;
     const binSeconds = binSecondsFor(lookback);
     setLoadingDeps(true);
     setError(null);
 
-    const pDeps = getDependencies(lookback, 'now')
-      .then((e) => {
-        if (!cancelled) setEdges(e);
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
-          setEdges([]);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingDeps(false);
-      });
-
-    listServiceSummaries(lookback, 'now')
-      .then((r) => {
-        if (!cancelled) setSummaries(r);
-      })
-      .catch(() => {
-        if (!cancelled) setSummaries([]);
-      });
-
-    // Previous-window summaries: feeds the traffic-drop detection
-    // in serviceHealth(). Non-fatal — if this fails we just lose
-    // the drop signal, which is still strictly better than the
-    // pre-existing error-rate-only path.
+    // Previous-window summaries always live — range-dependent,
+    // not cacheable. Fires in the background and feeds traffic-
+    // drop detection in serviceHealth().
     const prev = previousWindow(lookback);
     listServiceSummaries(prev.earliest, prev.latest)
       .then((r) => {
@@ -106,19 +89,70 @@ export default function SystemArchPage() {
         if (!cancelled) setPrevSummaries([]);
       });
 
-    getServiceTimeSeries(binSeconds, undefined, lookback, 'now')
-      .then((r) => {
-        if (!cancelled) setBuckets(r);
-      })
-      .catch(() => {
-        if (!cancelled) setBuckets([]);
-      });
+    const tryCache = async (): Promise<boolean> => {
+      if (lookback !== '-1h' || !streamFilterEnabled) return false;
+      try {
+        const cached = await listCachedSysarchPanels();
+        if (
+          cached.serviceSummaries &&
+          cached.serviceBuckets &&
+          cached.dependencies
+        ) {
+          if (cancelled) return true;
+          setSummaries(cached.serviceSummaries);
+          setBuckets(cached.serviceBuckets);
+          setEdges(cached.dependencies);
+          setLoadingDeps(false);
+          return true;
+        }
+      } catch {
+        /* fall through to live */
+      }
+      return false;
+    };
 
-    void pDeps;
+    (async () => {
+      const cacheHit = await tryCache();
+      if (cacheHit || cancelled) return;
+
+      // Cache miss — live queries.
+      const pDeps = getDependencies(lookback, 'now')
+        .then((e) => {
+          if (!cancelled) setEdges(e);
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setError(err instanceof Error ? err.message : String(err));
+            setEdges([]);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoadingDeps(false);
+        });
+
+      listServiceSummaries(lookback, 'now')
+        .then((r) => {
+          if (!cancelled) setSummaries(r);
+        })
+        .catch(() => {
+          if (!cancelled) setSummaries([]);
+        });
+
+      getServiceTimeSeries(binSeconds, undefined, lookback, 'now')
+        .then((r) => {
+          if (!cancelled) setBuckets(r);
+        })
+        .catch(() => {
+          if (!cancelled) setBuckets([]);
+        });
+
+      void pDeps;
+    })();
+
     return () => {
       cancelled = true;
     };
-  }, [lookback]);
+  }, [lookback, streamFilterEnabled]);
 
   function setLookback(value: string) {
     // Clear the legacy ?lookback= if present so we don't end up with


### PR DESCRIPTION
**Home page and System Architecture page now read their expensive panel queries from the scheduled-search caches (provisioned in PR #6) via a single batched \`\$vt_results\` read, falling through to the live query path on cache miss. Big wall-clock win.**

## Commits

- \`6fdb2c7\` — Home page: tries the cache first for \`-1h\` range + stream-filter-on. Any miss (scheduled search hasn't run yet, partial panel failure, non-default range) falls through to the existing live fetch path.
- \`69df2f1\` — System Architecture: same pattern. Cache provides service summaries + sparkline buckets + pre-merged \`DependencyEdge[]\` (RPC + messaging).

## What's in it

- \`panelCache.ts\` — single batched \`dataset="\$vt_results" | where jobName in (...)\` read, partitioned client-side by the auto-populated \`jobName\` column, fed into existing typed parsers. Reuses \`groupSlowTraceClasses\` / \`groupErrorClasses\` (extracted as shared helpers).
- \`HomePage.tsx\` and \`SystemArchPage.tsx\` gain a cache-fast path at the top of their fetchers.

## Cribl KQL gotcha documented

The \`\$vt_results\` docs advertise an inline array literal (\`jobName=["a","b"]\`) that doesn't actually parse in the top-of-pipeline position. The working form is \`| where jobName in (...)\`. Both the research doc and ROADMAP §2b.2 were updated to show the correct syntax.

## Validate from your phone

### Home page
Open https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/

| Metric | Before | After |
|---|---|---|
| Warm-tab Home load (rows visible) | ~8 s | ~3 s |
| Queries fired | 5-7 live panel queries | 1 batched cache read + 1 live prev-window |

Should feel noticeably snappier. All 18 services + sparklines + slow trace classes + error classes come from the cache.

### System Architecture
Click the System Architecture tab.

| Metric | Before | After |
|---|---|---|
| Nodes visible after click | ~15 s | ~3 s |

![Home cached](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/01-home-cached.png)

![System Architecture cached](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/02-sysarch-cached.png)

## Caveats

- **Stream-filter toggle disables the cache path.** Cached queries bake in the filter state at provision time. Flipping the toggle in Settings makes both pages fall back to live queries until you re-run Preview + Apply in the Settings provisioning panel (PR #6).
- **Dataset change doesn't re-provision automatically.** Same caveat — swap the dataset, then re-run Preview + Apply.
- **Non-default ranges (15m / 6h / 24h) always use the live path.** Scheduled searches run at 1h.

## Context

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)