### PR TITLE
oteldemo: anomaly detector reads durable baseline + widget re-enabled

### DIFF
--- a/oteldemo/src/api/queries.ts
+++ b/oteldemo/src/api/queries.ts
@@ -977,6 +977,65 @@ export function serviceMetricTimeSeries(
 }
 
 /**
+ * Latency anomaly detector that joins the current-window per-op
+ * p95 against the `criblapm_op_baselines` lookup maintained by
+ * the scheduled baseline search (§2b.1 in the ROADMAP). The join
+ * keeps the anomaly check to a single round trip and uses a
+ * hash-join against a cached CSV, so the read is sub-second even
+ * against an idle worker pool.
+ *
+ * Returns one row per anomalous (service, operation). Each row
+ * has: svc, op, curr_p95_us, prev_p95_us, ratio, requests.
+ *
+ * Filter chain:
+ *   - `isnotnull(prev_p95_us)` drops ops that aren't in the
+ *     baseline lookup (new ops since the last scheduled run).
+ *     Cache miss is NOT an anomaly — wait a schedule cycle.
+ *   - `prev_requests >= minBaselineRequests` skips baselines
+ *     with too few samples to be reliable.
+ *   - `curr_p95_us >= minCurrP95Us` skips sub-second "anomalies"
+ *     that nobody would act on (a 5× jump from 10ms → 50ms is
+ *     technically anomalous but noise-level).
+ *   - `curr_p95_us >= prev_p95_us * minRatio` is the core
+ *     "N× baseline" threshold.
+ *
+ * The lookup columns come back as strings because `export to
+ * lookup` emits CSV, so we `toreal()` them before comparing.
+ * Naming note: the current summarize produces a `requests`
+ * column and the lookup also has a `requests` column; the second
+ * shadows the first during join, so we alias to `curr_count`
+ * before the lookup to preserve it.
+ */
+export function operationAnomaliesFromLookup(
+  minRatio: number,
+  minCurrP95Us: number,
+  minBaselineRequests: number,
+  topN: number,
+): string {
+  return `${spansBase()}
+    | extend svc=tostring(resource.attributes['service.name']),
+             dur_us=(toreal(end_time_unix_nano)-toreal(start_time_unix_nano))/1000.0
+    ${streamFilterSpanKqlClause()}
+    | summarize curr_p95_us=percentile(dur_us, 95),
+                curr_count=count()
+      by svc, op=name
+    | lookup criblapm_op_baselines on svc, op
+    | extend prev_p95_us=toreal(p95_us),
+             prev_requests=toreal(requests)
+    | where isnotnull(prev_p95_us) and prev_p95_us > 0
+    | where curr_p95_us >= prev_p95_us * ${minRatio}
+      and curr_p95_us >= ${minCurrP95Us}
+      and prev_requests >= ${minBaselineRequests}
+    | project svc, op,
+              curr_p95_us,
+              prev_p95_us,
+              requests=curr_count,
+              ratio=curr_p95_us/prev_p95_us
+    | sort by ratio desc
+    | limit ${topN}`;
+}
+
+/**
  * Batched time-series: fetch (metric, bucket) → value for multiple
  * metrics in a single query. Used by the Service Detail page to
  * collapse 15+ per-row fetches on the Protocol/Runtime/Infrastructure

--- a/oteldemo/src/api/search.ts
+++ b/oteldemo/src/api/search.ts
@@ -411,76 +411,48 @@ const ANOMALY_MIN_RATIO = 5;
 const ANOMALY_MIN_CURR_P95_US = 1_000_000;
 
 /**
- * Per-op latency anomalies vs a long rolling baseline window. For
- * every (service, operation) present in both windows, compute
- * currP95 / baselineP95 and emit a row when the ratio crosses the
- * threshold AND the current p95 exceeds the absolute floor AND the
- * baseline window had enough samples to trust.
+ * Per-op latency anomalies vs the persisted `criblapm_op_baselines`
+ * lookup (written by the scheduled op-baseline search provisioned
+ * via ROADMAP §2b.1). One server-side query: current-window
+ * aggregation, hash-join against the lookup, filter by ratio +
+ * absolute threshold + baseline sample count. Returns
+ * OperationAnomaly[] ready for the widget.
  *
- * Why the baseline is not the immediately-prior window: an ongoing
- * incident that's been running for longer than the curr-window
- * length would poison a same-length prior window too, and the ratio
- * would sit at ~1× even though the op is clearly broken. A long
- * rolling baseline (default 24h preceding curr) includes enough
- * healthy history to survive multi-hour outages.
+ * Cache-miss semantics: if the lookup doesn't exist yet (fresh
+ * install, scheduled search hasn't run its first cycle) the
+ * query returns zero rows. The widget shows its empty state.
+ * The `wait for baselines to populate` UX copy is the caller's
+ * responsibility.
  *
- * Catches scenarios that absolute-duration ranking misses: e.g.,
- * accounting.order-consumed at 18s p95 vs a healthy baseline of
- * ~200ms (→ 90× ratio) won't show up on the Slowest Trace Classes
- * widget because its absolute duration is smaller than a legitimate
- * 60s image-load trace that's been streaming-filtered down to the
- * upper bound.
- *
- * TODO: as part of the reason-pill redesign, also expose per-op
- * error-rate delta, volume delta, and child-attribution delta so
- * the widget can show WHY an op was flagged and the user can
- * triage without opening Service Detail.
+ * TODO: reason pills — expose per-op error-rate delta, volume
+ * delta, and child-attribution delta so the widget can explain
+ * *why* an op was flagged instead of showing a bare ratio. See
+ * ROADMAP §2b.2 follow-ups.
  */
 export async function listOperationAnomalies(
-  earliest: string,
-  latest: string,
-  baselineEarliest: string,
-  baselineLatest: string,
+  earliest: string = '-1h',
+  latest: string = 'now',
   topN: number = 20,
 ): Promise<OperationAnomaly[]> {
-  const [currRows, baselineRows] = await Promise.all([
-    runQuery(Q.allOperationsSummary(), earliest, latest, 1000),
-    runQuery(Q.allOperationsSummary(), baselineEarliest, baselineLatest, 1000),
-  ]);
-  const baselineMap = new Map<string, { p95: number; count: number }>();
-  for (const r of baselineRows) {
-    const key = `${String(r.svc ?? '')}\u0000${String(r.op ?? '')}`;
-    baselineMap.set(key, {
-      p95: toNum(r.p95_us),
-      count: toNum(r.requests),
-    });
-  }
-  const anomalies: OperationAnomaly[] = [];
-  for (const r of currRows) {
-    const svc = String(r.svc ?? '');
-    const op = String(r.op ?? '');
-    if (!svc || !op) continue;
-    const key = `${svc}\u0000${op}`;
-    const baseline = baselineMap.get(key);
-    if (!baseline) continue;
-    if (baseline.count < ANOMALY_MIN_BASELINE_REQUESTS) continue;
-    const prevP95 = baseline.p95;
-    if (prevP95 <= 0) continue;
-    const currP95 = toNum(r.p95_us);
-    if (currP95 < ANOMALY_MIN_CURR_P95_US) continue;
-    const ratio = currP95 / prevP95;
-    if (ratio < ANOMALY_MIN_RATIO) continue;
-    anomalies.push({
-      service: svc,
-      operation: op,
-      currP95Us: currP95,
-      prevP95Us: prevP95,
-      ratio,
-      requests: toNum(r.requests),
-    });
-  }
-  anomalies.sort((a, b) => b.ratio - a.ratio);
-  return anomalies.slice(0, topN);
+  const rows = await runQuery(
+    Q.operationAnomaliesFromLookup(
+      ANOMALY_MIN_RATIO,
+      ANOMALY_MIN_CURR_P95_US,
+      ANOMALY_MIN_BASELINE_REQUESTS,
+      topN,
+    ),
+    earliest,
+    latest,
+    topN,
+  );
+  return rows.map((r) => ({
+    service: String(r.svc ?? ''),
+    operation: String(r.op ?? ''),
+    currP95Us: toNum(r.curr_p95_us),
+    prevP95Us: toNum(r.prev_p95_us),
+    ratio: toNum(r.ratio),
+    requests: toNum(r.requests),
+  }));
 }
 
 function percentile(values: number[], p: number): number {

--- a/oteldemo/src/routes/HomePage.module.css
+++ b/oteldemo/src/routes/HomePage.module.css
@@ -263,6 +263,16 @@
   gap: var(--cds-space-lg);
 }
 
+/* Full-width panel row — the latency-anomaly widget sits above
+ * the two-column slow / error row. Anomaly rows carry enough text
+ * (op name + before/after p95 + count + ratio pill) that a
+ * half-column would clip. */
+.panelsFull {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--cds-space-lg);
+}
+
 @media (max-width: 900px) {
   .panels {
     grid-template-columns: 1fr;

--- a/oteldemo/src/routes/HomePage.tsx
+++ b/oteldemo/src/routes/HomePage.tsx
@@ -5,11 +5,13 @@ import { binSecondsFor } from '../components/timeRanges';
 import Sparkline from '../components/Sparkline';
 import StatusBanner from '../components/StatusBanner';
 import TraceClassList, { type ClassItem } from '../components/TraceClassList';
+import OperationAnomalyList from '../components/OperationAnomalyList';
 import {
   listServiceSummaries,
   getServiceTimeSeries,
   listSlowTraceClasses,
   listErrorClasses,
+  listOperationAnomalies,
 } from '../api/search';
 import { listCachedHomePanels } from '../api/panelCache';
 import { serviceColor } from '../utils/spans';
@@ -23,21 +25,8 @@ import type {
   ServiceBucket,
   SlowTraceClass,
   ErrorClass,
+  OperationAnomaly,
 } from '../api/types';
-
-// NOTE: the latency-anomaly widget + its fetch wiring were removed
-// from this page pending ROADMAP §2b (durable baselines via
-// scheduled Cribl Saved Searches). The in-memory 24h baseline it
-// needed cost ~22s per refresh and couldn't survive incidents
-// older than the baseline window, which made it fire noisily.
-// The building blocks are parked intact and ready to plug back in
-// once the baseline source is durable:
-//   - src/components/OperationAnomalyList.tsx
-//   - src/api/search.ts::listOperationAnomalies
-//   - src/api/queries.ts::allOperationsSummary
-//   - src/api/types.ts::OperationAnomaly
-//   - src/utils/health.ts::latency_anomaly bucket + serviceHealth
-//     `anomalousServices` arg (currently always undefined)
 import s from './HomePage.module.css';
 
 type SortKey =
@@ -111,10 +100,12 @@ export default function HomePage() {
   const [buckets, setBuckets] = useState<ServiceBucket[]>([]);
   const [slowClasses, setSlowClasses] = useState<SlowTraceClass[]>([]);
   const [errorClasses, setErrorClasses] = useState<ErrorClass[]>([]);
+  const [anomalies, setAnomalies] = useState<OperationAnomaly[]>([]);
   const [loadingSummaries, setLoadingSummaries] = useState(true);
   const [loadingBuckets, setLoadingBuckets] = useState(true);
   const [loadingSlow, setLoadingSlow] = useState(true);
   const [loadingErrors, setLoadingErrors] = useState(true);
+  const [loadingAnomalies, setLoadingAnomalies] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshMs, setRefreshMs] = useState<number>(DEFAULT_REFRESH_MS);
   const [sort, setSort] = useState<SortState>({ key: 'requests', dir: 'desc' });
@@ -132,6 +123,7 @@ export default function HomePage() {
     setLoadingBuckets(true);
     setLoadingSlow(true);
     setLoadingErrors(true);
+    setLoadingAnomalies(true);
 
     // Previous window of the same length — fuels the delta-vs-baseline
     // chips. Failure here is non-fatal; we just skip the chips. Fired
@@ -141,6 +133,17 @@ export default function HomePage() {
     const pPrevSummaries = listServiceSummaries(prev.earliest, prev.latest)
       .then((r) => setPrevSummaries(r))
       .catch(() => setPrevSummaries([]));
+
+    // Latency anomaly detection — joins the current window against
+    // the criblapm_op_baselines lookup maintained by the scheduled
+    // baseline search (ROADMAP §2b.1). Fires unconditionally in the
+    // background; populates the anomaly widget when it lands. If
+    // the lookup doesn't exist yet (fresh install), the query
+    // returns zero rows and the widget shows its empty state.
+    const pAnomalies = listOperationAnomalies(range, 'now')
+      .then((r) => setAnomalies(r))
+      .catch(() => setAnomalies([]))
+      .finally(() => setLoadingAnomalies(false));
 
     // Cache-fast path: when the user is on the default -1h range,
     // try a single batched $vt_results read for all four panels
@@ -171,9 +174,10 @@ export default function HomePage() {
           setLoadingBuckets(false);
           setLoadingSlow(false);
           setLoadingErrors(false);
-          // Don't await the prev summary here — let it resolve in
-          // the background and light up the delta chips when it
-          // lands. The main catalog is already usable.
+          // Don't await the prev summary or anomaly query here —
+          // let them resolve in the background and light up the
+          // delta chips + anomaly widget when they land. The main
+          // catalog is already usable.
           setLastRefresh(Date.now());
           return;
         }
@@ -209,7 +213,14 @@ export default function HomePage() {
       .catch(() => setErrorClasses([]))
       .finally(() => setLoadingErrors(false));
 
-    await Promise.allSettled([pSummaries, pPrevSummaries, pBuckets, pSlow, pErrors]);
+    await Promise.allSettled([
+      pSummaries,
+      pPrevSummaries,
+      pBuckets,
+      pSlow,
+      pErrors,
+      pAnomalies,
+    ]);
     setLastRefresh(Date.now());
     // streamFilterEnabled is in the dep list so (a) flipping the
     // toggle triggers a re-fetch and (b) the cache-fast path
@@ -240,6 +251,16 @@ export default function HomePage() {
     for (const svc of prevSummaries) m.set(svc.service, svc);
     return m;
   }, [prevSummaries]);
+
+  // Services with at least one anomalous operation — used by
+  // serviceHealth() to tint the catalog row cyan when any op for
+  // that service is flagged, regardless of where it ranks in the
+  // anomaly widget's own table.
+  const anomalousServices = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of anomalies) set.add(a.service);
+    return set;
+  }, [anomalies]);
 
   // Group time-series buckets by service for sparklines
   const sparksByService = useMemo(() => {
@@ -403,14 +424,14 @@ export default function HomePage() {
                 // wrong direction.
                 const prevRaw = prevByService.get(svc.service);
                 const prev = prevRaw && prevRaw.requests >= MIN_PREV_SAMPLES ? prevRaw : undefined;
-                // serviceHealth takes the previous window so it can
-                // promote to `traffic_drop` when requests fall off
-                // sharply vs baseline — the classic kafka-lag /
-                // starved-consumer signal that error-rate-only
-                // bucketing misses. The `latency_anomaly` path is
-                // plumbed but disabled until ROADMAP §2b lands a
-                // durable baseline source.
-                const health = serviceHealth(svc, prevRaw);
+                // serviceHealth takes the previous window + the
+                // anomalous-services set so it can promote a row
+                // to `traffic_drop` (rate fell off sharply vs
+                // baseline) or `latency_anomaly` (some op for this
+                // service is 5×+ slower than its durable baseline).
+                // Both signals that error-rate-only bucketing
+                // misses.
+                const health = serviceHealth(svc, prevRaw, anomalousServices);
                 const rowBg = healthRowBg(health.bucket);
                 const prevReqPerMin = prev ? reqPerMin(prev.requests) : undefined;
                 return (
@@ -495,6 +516,17 @@ export default function HomePage() {
             </tbody>
           </table>
         )}
+      </div>
+
+      {/* Latency anomaly panel — full width, sits above the
+          slow / error row. Only surfaces actionable rows; when
+          nothing is anomalous the widget shows its empty state. */}
+      <div className={s.panelsFull}>
+        <OperationAnomalyList
+          items={anomalies}
+          loading={loadingAnomalies}
+          lookback={range}
+        />
       </div>
 
       {/* Bottom panels: slow trace classes + error classes */}

--- a/oteldemo/src/utils/health.ts
+++ b/oteldemo/src/utils/health.ts
@@ -71,16 +71,12 @@ export function healthRowBg(bucket: HealthBucket): string {
   return HEALTH_BG[bucket];
 }
 
-// `latency_anomaly` is intentionally absent from HEALTH_LEGEND right
-// now because nothing in the app actually feeds `anomalousServices`
-// into `serviceHealth()`. See the HomePage.tsx breadcrumb and
-// ROADMAP §2b for why — re-add this line when the durable baseline
-// source lands and the widget gets re-wired.
 export const HEALTH_LEGEND: Array<{ bucket: HealthBucket; color: string; label: string }> = [
   { bucket: 'healthy', ...HEALTH.healthy },
   { bucket: 'watch', ...HEALTH.watch },
   { bucket: 'warn', ...HEALTH.warn },
   { bucket: 'critical', ...HEALTH.critical },
+  { bucket: 'latency_anomaly', ...HEALTH.latency_anomaly },
   { bucket: 'traffic_drop', ...HEALTH.traffic_drop },
   { bucket: 'idle', ...HEALTH.idle },
 ];


### PR DESCRIPTION
**The \`OperationAnomalyList\` widget parked in PR #3 is back on the Home page, powered by the \`criblapm_op_baselines\` lookup that the scheduled baseline search writes on its hourly cron (provisioned in PR #6). Closes out ROADMAP §2b.**

## Commits

- \`858f0b4\` — new \`operationAnomaliesFromLookup\` KQL builder, rewritten \`listOperationAnomalies\` verb (single server-side query with lookup join + filter), re-enabled widget, restored \`latency_anomaly\` in \`HEALTH_LEGEND\`, threaded \`anomalousServices\` back through \`serviceHealth()\` for catalog row tints.

## Wall-clock comparison

| | Before | After |
|---|---|---|
| Anomaly query | ~22 s per Home refresh (24 h live span-range query) | ~1 s (server-side lookup join against pre-computed CSV) |
| Multi-hour-incident survival | No (rolling baseline poisoned) | Yes (baseline is whatever the last hourly run captured) |

## Query shape

\`\`\`kql
${spans}
  | extend svc=..., dur_us=...
  | where dur_us < 30000000
  | summarize curr_p95_us=percentile(dur_us, 95), curr_count=count() by svc, op=name
  | lookup criblapm_op_baselines on svc, op
  | extend prev_p95_us=toreal(p95_us), prev_requests=toreal(requests)
  | where isnotnull(prev_p95_us) and prev_p95_us > 0
  | where curr_p95_us >= prev_p95_us * 5
    and curr_p95_us >= 1000000
    and prev_requests >= 20
  | project svc, op, curr_p95_us, prev_p95_us, requests=curr_count, ratio=...
  | sort by ratio desc
  | limit 20
\`\`\`

Lookup columns come back as strings (CSV) so every comparison \`toreal()\`s before filtering. The \`requests\` column name collides with the current-window count so the summarize aliases to \`curr_count\` and the final project renames back.

## Validate from your phone

Open https://main-objective-shirley-sho21r7.cribl-staging.cloud/apps/oteldemo/ and scroll below the service catalog.

**Latency anomalies** widget should be visible above the Slowest trace classes / Error classes row. Current state: **empty** — which is expected. The \`criblapm_op_baselines\` lookup was materialized while the kafka scenario was still running, so every op is within ~1× of its own baseline (ratio 0.99×). This is the limitation ROADMAP §2b.1 explicitly documents.

![Anomalies widget with empty state](https://raw.githubusercontent.com/criblio/otel-demo-criblcloud/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/assets/05-anomalies-widget.png)

**To test that the detector actually fires**: turn the kafka scenario OFF, wait for the next hourly baseline run (top of the next hour), then turn it back ON. The new baseline will be healthy so the scenario will trip the 5× threshold on \`accounting.order-consumed\` and light up the widget.

\`\`\`bash
scripts/flagd-set.sh kafkaQueueProblems off
# wait for the next top-of-hour
scripts/flagd-set.sh kafkaQueueProblems on
# wait ~5 min for new spans to accumulate, then reload Home
\`\`\`

## Context

This is the last PR in today's stack. After this merges, \$vt_results-backed panel caching and lookup-backed anomaly detection are both live on staging.

Session log: [docs/session-logs/2026-04-11-durable-baselines/README.md](https://github.com/criblio/otel-demo-criblcloud/blob/jaeger-clone/docs/session-logs/2026-04-11-durable-baselines/README.md)