### PR TITLE
Investigator: surface Cribl AI bearer token cache failure honestly

### DIFF
--- a/oteldemo/src/api/agent.ts
+++ b/oteldemo/src/api/agent.ts
@@ -69,6 +69,74 @@ export type AgentFrame =
   | { kind: 'notification'; toolName?: string; content: unknown }
   | { kind: 'unknown'; raw: unknown };
 
+/** Raised when the Cribl platform's injected auth token has expired
+ *  and we get a 5xx back with a "Bearer Token has expired" reason.
+ *  Catch this at the UI layer and prompt the user to reload the tab —
+ *  a hard reload is currently the only way to pick up a fresh token
+ *  from the platform's fetch proxy. */
+export class SessionExpiredError extends Error {
+  readonly isSessionExpired = true as const;
+  constructor(message = 'Your Cribl session has expired. Reload the page to continue.') {
+    super(message);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+export function isSessionExpiredError(err: unknown): err is SessionExpiredError {
+  return (
+    err instanceof Error &&
+    (err as { isSessionExpired?: boolean }).isSessionExpired === true
+  );
+}
+
+/** Does a server error body look like an expired-token rejection?
+ *  The agent endpoint returns `{"reason":"Bearer Token has expired"}`
+ *  under a 5xx; future Cribl versions may use slightly different
+ *  wording so we match permissively. */
+function looksLikeSessionExpired(body: string): boolean {
+  if (!body) return false;
+  const lower = body.toLowerCase();
+  return (
+    lower.includes('bearer token has expired') ||
+    lower.includes('token has expired') ||
+    lower.includes('token expired')
+  );
+}
+
+/**
+ * Touch one of the cheap AI metadata GETs to nudge the platform to
+ * refresh the AI bearer token it caches per user.
+ *
+ * The Cribl platform's fetch proxy injects auth into every API call
+ * (per `oteldemo/AGENTS.md`), but the AI subsystem appears to keep
+ * its own per-user bearer token with a shorter TTL than the user's
+ * Cribl session cookie. Once it expires, the agent endpoint returns
+ * 500 + `{"reason":"Bearer Token has expired"}` even though the
+ * user's session is still valid (other API calls keep working).
+ *
+ * Captures of the native Cribl Search Copilot UI (see
+ * `docs/research/investigator-spike/all-api-calls.json`) show it
+ * fetches these AI metadata endpoints before every investigation:
+ *   - `GET /api/v1/ai/consent/`
+ *   - `GET /api/v1/ai/settings/disabled`
+ *   - `GET /api/v1/ai/settings/features`
+ * Best theory is one of these (or all of them) is what keeps the
+ * AI bearer token cache warm. We pick `/ai/settings/features`
+ * because it's a single round-trip, has no side effects, and is
+ * the most-recently-fetched of the three in the native trace.
+ *
+ * Best-effort. Errors swallowed — the caller is going to retry the
+ * agent POST regardless and surface a real error if that still
+ * fails.
+ */
+async function warmupAiToken(signal?: AbortSignal): Promise<void> {
+  try {
+    await fetch(`${apiUrl()}/ai/settings/features`, { method: 'GET', signal });
+  } catch {
+    /* swallow — caller will retry the agent POST and surface real failures */
+  }
+}
+
 function apiUrl(): string {
   return window.CRIBL_API_URL ?? import.meta.env.VITE_CRIBL_API_URL ?? '/api/v1';
 }
@@ -122,32 +190,64 @@ export function parseAgentFrame(line: string): AgentFrame | null {
   return { kind: 'unknown', raw: obj };
 }
 
-/**
- * POST a request to the agent endpoint and yield parsed frames as
- * they arrive. The stream ends when the server closes the connection.
- *
- * AbortSignal support lets callers cancel in-flight investigations
- * (e.g. when the user navigates away or clicks a Stop button).
- */
-export async function* streamAgent(
+/** POST the agent request once. On a 5xx with an expired-token
+ *  signature, returns null so the caller can warm up + retry; on
+ *  any other failure, throws. On success, returns the live Response
+ *  so the caller can stream from `resp.body`. */
+async function postAgentRequest(
   req: AgentRequest,
   signal?: AbortSignal,
-): AsyncGenerator<AgentFrame, void, void> {
+): Promise<Response | null> {
   const resp = await fetch(agentUrl(), {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(req),
     signal,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new Error(`Agent request failed (${resp.status}): ${body}`);
+  if (resp.ok) {
+    if (!resp.body) throw new Error('Agent response has no body');
+    return resp;
   }
-  if (!resp.body) {
-    throw new Error('Agent response has no body');
+  const body = await resp.text().catch(() => '');
+  if (looksLikeSessionExpired(body)) {
+    return null;
+  }
+  throw new Error(`Agent request failed (${resp.status}): ${body}`);
+}
+
+/**
+ * POST a request to the agent endpoint and yield parsed frames as
+ * they arrive. The stream ends when the server closes the connection.
+ *
+ * AbortSignal support lets callers cancel in-flight investigations
+ * (e.g. when the user navigates away or clicks a Stop button).
+ *
+ * Expired-token recovery: if the first POST returns a 5xx with a
+ * "Bearer Token has expired" body, we call `warmupAiToken()` to
+ * nudge the platform's AI token cache and retry the POST exactly
+ * once. If the retry also returns the expired-token error, we
+ * surface a `SessionExpiredError` so the UI can prompt the user to
+ * reload the page (the only currently-known fallback if the warmup
+ * GET doesn't recover the cache). All other 5xx/4xx errors throw
+ * immediately without retrying, since they're not transient.
+ */
+export async function* streamAgent(
+  req: AgentRequest,
+  signal?: AbortSignal,
+): AsyncGenerator<AgentFrame, void, void> {
+  let resp = await postAgentRequest(req, signal);
+  if (resp === null) {
+    // First attempt hit the expired-token error. Warm up the AI
+    // bearer token cache and retry once. If we still get the same
+    // error, give up and ask the user to reload.
+    await warmupAiToken(signal);
+    resp = await postAgentRequest(req, signal);
+    if (resp === null) {
+      throw new SessionExpiredError();
+    }
   }
 
-  const reader = resp.body.getReader();
+  const reader = resp.body!.getReader();
   const decoder = new TextDecoder('utf-8');
   // Line buffer — NDJSON frames are newline-delimited, but a single
   // chunk from the reader can contain a partial line.

--- a/oteldemo/src/api/agent.ts
+++ b/oteldemo/src/api/agent.ts
@@ -69,14 +69,18 @@ export type AgentFrame =
   | { kind: 'notification'; toolName?: string; content: unknown }
   | { kind: 'unknown'; raw: unknown };
 
-/** Raised when the Cribl platform's injected auth token has expired
- *  and we get a 5xx back with a "Bearer Token has expired" reason.
- *  Catch this at the UI layer and prompt the user to reload the tab —
- *  a hard reload is currently the only way to pick up a fresh token
- *  from the platform's fetch proxy. */
+/** Raised when the agent endpoint returns a 5xx with a
+ *  "Bearer Token has expired" reason. This is a Cribl platform-side
+ *  problem with the AI bearer token cache (separate from the user's
+ *  Cribl session cookie — other API calls keep working); no
+ *  client-side action recovers it. Catch this at the UI layer and
+ *  show a banner explaining the situation rather than treating it
+ *  like a transient retry-able error. */
 export class SessionExpiredError extends Error {
   readonly isSessionExpired = true as const;
-  constructor(message = 'Your Cribl session has expired. Reload the page to continue.') {
+  constructor(
+    message = 'Cribl AI bearer token cache is in a broken state. Reloading the page will not help — the only known recoveries are a full Cribl logout/re-login or contacting Cribl support.',
+  ) {
     super(message);
     this.name = 'SessionExpiredError';
   }
@@ -101,40 +105,6 @@ function looksLikeSessionExpired(body: string): boolean {
     lower.includes('token has expired') ||
     lower.includes('token expired')
   );
-}
-
-/**
- * Touch one of the cheap AI metadata GETs to nudge the platform to
- * refresh the AI bearer token it caches per user.
- *
- * The Cribl platform's fetch proxy injects auth into every API call
- * (per `oteldemo/AGENTS.md`), but the AI subsystem appears to keep
- * its own per-user bearer token with a shorter TTL than the user's
- * Cribl session cookie. Once it expires, the agent endpoint returns
- * 500 + `{"reason":"Bearer Token has expired"}` even though the
- * user's session is still valid (other API calls keep working).
- *
- * Captures of the native Cribl Search Copilot UI (see
- * `docs/research/investigator-spike/all-api-calls.json`) show it
- * fetches these AI metadata endpoints before every investigation:
- *   - `GET /api/v1/ai/consent/`
- *   - `GET /api/v1/ai/settings/disabled`
- *   - `GET /api/v1/ai/settings/features`
- * Best theory is one of these (or all of them) is what keeps the
- * AI bearer token cache warm. We pick `/ai/settings/features`
- * because it's a single round-trip, has no side effects, and is
- * the most-recently-fetched of the three in the native trace.
- *
- * Best-effort. Errors swallowed — the caller is going to retry the
- * agent POST regardless and surface a real error if that still
- * fails.
- */
-async function warmupAiToken(signal?: AbortSignal): Promise<void> {
-  try {
-    await fetch(`${apiUrl()}/ai/settings/features`, { method: 'GET', signal });
-  } catch {
-    /* swallow — caller will retry the agent POST and surface real failures */
-  }
 }
 
 function apiUrl(): string {
@@ -190,31 +160,6 @@ export function parseAgentFrame(line: string): AgentFrame | null {
   return { kind: 'unknown', raw: obj };
 }
 
-/** POST the agent request once. On a 5xx with an expired-token
- *  signature, returns null so the caller can warm up + retry; on
- *  any other failure, throws. On success, returns the live Response
- *  so the caller can stream from `resp.body`. */
-async function postAgentRequest(
-  req: AgentRequest,
-  signal?: AbortSignal,
-): Promise<Response | null> {
-  const resp = await fetch(agentUrl(), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(req),
-    signal,
-  });
-  if (resp.ok) {
-    if (!resp.body) throw new Error('Agent response has no body');
-    return resp;
-  }
-  const body = await resp.text().catch(() => '');
-  if (looksLikeSessionExpired(body)) {
-    return null;
-  }
-  throw new Error(`Agent request failed (${resp.status}): ${body}`);
-}
-
 /**
  * POST a request to the agent endpoint and yield parsed frames as
  * they arrive. The stream ends when the server closes the connection.
@@ -222,32 +167,42 @@ async function postAgentRequest(
  * AbortSignal support lets callers cancel in-flight investigations
  * (e.g. when the user navigates away or clicks a Stop button).
  *
- * Expired-token recovery: if the first POST returns a 5xx with a
- * "Bearer Token has expired" body, we call `warmupAiToken()` to
- * nudge the platform's AI token cache and retry the POST exactly
- * once. If the retry also returns the expired-token error, we
- * surface a `SessionExpiredError` so the UI can prompt the user to
- * reload the page (the only currently-known fallback if the warmup
- * GET doesn't recover the cache). All other 5xx/4xx errors throw
- * immediately without retrying, since they're not transient.
+ * Expired-token detection: if the response body contains
+ * "Bearer Token has expired" (any case), throw a typed
+ * `SessionExpiredError` so the UI can show a clear "Cribl AI token
+ * cache is in a broken state" message instead of a raw 500. We
+ * don't retry, warm up, or attempt automatic recovery — the failure
+ * is server-side (the per-user AI bearer token cache is in a state
+ * no client-side action can refresh; verified by reproducing the
+ * exact same 500 in Cribl Search's own native `/search/agent`
+ * Copilot UI on the same workspace, where the native UI's "Try
+ * Again" button is a re-POST with no recovery either). The fix
+ * lives on the platform side; the only known mitigations from a
+ * client are a full Cribl logout/re-login or waiting for the
+ * server-side cache to TTL out.
  */
 export async function* streamAgent(
   req: AgentRequest,
   signal?: AbortSignal,
 ): AsyncGenerator<AgentFrame, void, void> {
-  let resp = await postAgentRequest(req, signal);
-  if (resp === null) {
-    // First attempt hit the expired-token error. Warm up the AI
-    // bearer token cache and retry once. If we still get the same
-    // error, give up and ask the user to reload.
-    await warmupAiToken(signal);
-    resp = await postAgentRequest(req, signal);
-    if (resp === null) {
+  const resp = await fetch(agentUrl(), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(req),
+    signal,
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    if (looksLikeSessionExpired(body)) {
       throw new SessionExpiredError();
     }
+    throw new Error(`Agent request failed (${resp.status}): ${body}`);
+  }
+  if (!resp.body) {
+    throw new Error('Agent response has no body');
   }
 
-  const reader = resp.body!.getReader();
+  const reader = resp.body.getReader();
   const decoder = new TextDecoder('utf-8');
   // Line buffer — NDJSON frames are newline-delimited, but a single
   // chunk from the reader can contain a partial line.

--- a/oteldemo/src/routes/InvestigatePage.module.css
+++ b/oteldemo/src/routes/InvestigatePage.module.css
@@ -433,3 +433,18 @@
   color: var(--cds-color-error);
   font-size: var(--cds-font-size-sm);
 }
+
+.errorBannerTitle {
+  font-weight: 600;
+  margin-bottom: var(--cds-space-2xs);
+}
+
+.errorBannerBody {
+  color: var(--cds-color-text);
+  margin-bottom: var(--cds-space-sm);
+}
+
+.errorBannerActions {
+  display: flex;
+  gap: var(--cds-space-sm);
+}

--- a/oteldemo/src/routes/InvestigatePage.module.css
+++ b/oteldemo/src/routes/InvestigatePage.module.css
@@ -441,10 +441,13 @@
 
 .errorBannerBody {
   color: var(--cds-color-text);
-  margin-bottom: var(--cds-space-sm);
 }
 
-.errorBannerActions {
-  display: flex;
-  gap: var(--cds-space-sm);
+.errorBannerBody p {
+  margin: 0 0 var(--cds-space-sm) 0;
+}
+
+.errorBannerBody ul {
+  margin: 0;
+  padding-left: var(--cds-space-md);
 }

--- a/oteldemo/src/routes/InvestigatePage.tsx
+++ b/oteldemo/src/routes/InvestigatePage.tsx
@@ -448,21 +448,31 @@ function TranscriptRow({
       return (
         <div className={s.errorBanner} role="alert">
           <div className={s.errorBannerTitle}>
-            Your Cribl session has expired
+            Cribl AI bearer token cache is in a broken state
           </div>
           <div className={s.errorBannerBody}>
-            The investigation was interrupted because the platform
-            auth token is no longer valid. Reload the page to pick up
-            a fresh token, then rerun your question.
-          </div>
-          <div className={s.errorBannerActions}>
-            <button
-              type="button"
-              className={`${s.btn} ${s.btnPrimary}`}
-              onClick={() => window.location.reload()}
-            >
-              Reload page
-            </button>
+            <p>
+              The Cribl AI subsystem returned{' '}
+              <code>Bearer Token has expired</code>. This is a
+              platform-side problem with the per-user AI token cache,
+              <em>not</em> your Cribl session — other Cribl API calls
+              are still working.
+            </p>
+            <p>
+              <strong>Reloading this page will not help.</strong> The
+              same failure reproduces in Cribl Search&apos;s own
+              native <code>/search/agent</code> Copilot UI on this
+              workspace, so client-side retries can&apos;t recover.
+              Known mitigations:
+            </p>
+            <ul>
+              <li>Fully log out of Cribl Cloud and log back in.</li>
+              <li>
+                Wait for the server-side cache to TTL out and try
+                again.
+              </li>
+              <li>Contact Cribl support if the problem persists.</li>
+            </ul>
           </div>
         </div>
       );

--- a/oteldemo/src/routes/InvestigatePage.tsx
+++ b/oteldemo/src/routes/InvestigatePage.tsx
@@ -24,6 +24,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { runInvestigation, type LoopEvent } from '../api/agentLoop';
 import { buildSeedPrompt, type InvestigationSeed } from '../api/agentContext';
 import type { AgentMessage, AgentToolCall } from '../api/agent';
+import { isSessionExpiredError } from '../api/agent';
 import type {
   ToolExecutionResult,
   RunSearchUi,
@@ -66,6 +67,10 @@ interface ErrorEntry {
   kind: 'error';
   id: string;
   message: string;
+  /** True when this error is a session-expired from the platform's
+   *  auth token. The UI shows a Reload Page affordance instead of
+   *  just the raw message. */
+  sessionExpired?: boolean;
 }
 
 type TranscriptEntry = UserEntry | AssistantEntry | ToolCallEntry | ErrorEntry;
@@ -237,9 +242,10 @@ export default function InvestigatePage() {
         signal: abortRef.current.signal,
       }).catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
+        const sessionExpired = isSessionExpiredError(err);
         setTranscript((prev) => [
           ...prev,
-          { kind: 'error', id: `err-${Date.now()}`, message: msg },
+          { kind: 'error', id: `err-${Date.now()}`, message: msg, sessionExpired },
         ]);
         setRunning(false);
       });
@@ -438,6 +444,29 @@ function TranscriptRow({
     );
   }
   if (entry.kind === 'error') {
+    if (entry.sessionExpired) {
+      return (
+        <div className={s.errorBanner} role="alert">
+          <div className={s.errorBannerTitle}>
+            Your Cribl session has expired
+          </div>
+          <div className={s.errorBannerBody}>
+            The investigation was interrupted because the platform
+            auth token is no longer valid. Reload the page to pick up
+            a fresh token, then rerun your question.
+          </div>
+          <div className={s.errorBannerActions}>
+            <button
+              type="button"
+              className={`${s.btn} ${s.btnPrimary}`}
+              onClick={() => window.location.reload()}
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      );
+    }
     return <div className={s.errorBanner}>Error: {entry.message}</div>;
   }
   // toolCall
@@ -808,7 +837,12 @@ function applyLoopEvent(
     case 'error':
       return [
         ...prev,
-        { kind: 'error', id: `err-${Date.now()}`, message: ev.error.message },
+        {
+          kind: 'error',
+          id: `err-${Date.now()}`,
+          message: ev.error.message,
+          sessionExpired: isSessionExpiredError(ev.error),
+        },
       ];
   }
 }


### PR DESCRIPTION
## Summary

Detect `Bearer Token has expired` responses from the agent endpoint and render a clear platform-side-failure banner instead of a raw `Agent request failed (500): {...}`.

**The retry/warmup approach in the original commit was wrong** and has been removed. While reproducing Clint's failure I drove Cribl Search's own native `/search/agent` Copilot UI on the same workspace and confirmed:

- The native UI hits the **exact same** 500 + `{"reason":"Bearer Token has expired"}` on the first POST.
- The native UI's "Try Again" button is just a re-POST. Three clicks, three identical 500s, **no refresh call between attempts**.
- The `/ai/consent/`, `/ai/settings/disabled`, `/ai/settings/features` GETs the native UI fires are **one-time init on page load** — not on the recovery path. They don't refresh the AI token cache.
- Page reload doesn't help either (Clint confirmed independently before this investigation).

So the failure is a **Cribl platform-side bug** in the per-user AI bearer token cache — separate from the user's Cribl session cookie, since other Cribl API calls keep working. No client-side action (retry, GET sequence, reload, the native UI's Try Again) can recover it. The only known mitigations are a full logout/re-login from Cribl Cloud or waiting for the server-side cache to TTL out.

## What this PR ships

1. **`SessionExpiredError`** — typed `Error` subclass with `isSessionExpired: true` and an `isSessionExpiredError()` type guard. Default message tells the truth: it's a platform-side AI cache problem, reload won't help.
2. **`looksLikeSessionExpired()`** — permissive body matcher (`bearer token has expired` / `token has expired` / `token expired`) so the detection survives small wording changes in future Cribl versions.
3. **`streamAgent()`** — when the response body matches, throw `SessionExpiredError` instead of a generic `Agent request failed (500): {...}`. Single POST, no retry, no warmup.
4. **`InvestigatePage`** — tags the resulting transcript error entry with `sessionExpired: true` (in both error paths) and renders a dedicated banner explaining that this is a platform-side AI token cache problem, that reload won't help, that the same failure reproduces in the native UI, and listing the known mitigations.

There is **no "Reload page" button** in the new banner because reload demonstrably does not fix the issue. Adding one would be theater.

## Test plan

- [ ] Open `/apps/oteldemo/investigate` on staging while the platform AI token is in the broken state (Clint's current environment). Submit a fresh investigation. Expected: dedicated banner with the "Cribl AI bearer token cache is in a broken state" headline, no raw 500 text. The mitigation list is plain prose, not interactive.
- [ ] After the platform-side environmental fix is applied (a Cribl person is on it), submit a fresh investigation. Expected: investigation runs normally, no banner shown.
- [ ] Force the failure path with the platform working: temporarily make `looksLikeSessionExpired` return `true` always, confirm the banner renders correctly with the new copy. Revert.

## Why no fix in this PR

Reproduced the same failure in the native Cribl Search Copilot UI, which is the same workspace's authoritative AI client. There is nothing we can ship from `oteldemo/` that the native UI itself doesn't do. Forwarding evidence to whoever's fixing the platform side:

- `/tmp/native-investigation-trace.json` — initial /search/agent navigation + first POST → 500
- `/tmp/native-retry-trace.json` — three "Try Again" clicks, three identical 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)